### PR TITLE
Use Location instead of Zone for gke datagatherer configuration

### DIFF
--- a/docs/datagatherers/gke.md
+++ b/docs/datagatherers/gke.md
@@ -9,7 +9,7 @@ It pulls information about one cluster from the GKE API.
 You have to set these parameters in the configuration:
 
 - **project:** the ID of your Google Cloud Platform project.
-- **zone:** the compute zone where your cluster is running.
+- **location:** the compute zone or region where your cluster is running.
 - **cluster:** the name of your GKE cluster.
 - **credentials** *optional* **:** path to a file containing valid credentials for your cluster. Useful if you want to configure a separate service account. If not specified, it will attept to use Workload Identity. If you run Preflight locally on your machine, you can just run `gcloud auth application-default login`
 

--- a/examples/gke.preflight.yaml
+++ b/examples/gke.preflight.yaml
@@ -8,7 +8,7 @@ cluster-name: my-cluster
 data-gatherers:
   gke:
     project: my-gcp-project
-    zone: us-central1-a
+    location: us-central1-a
     cluster: my-gke-cluster
     # Path to a file containing the credentials. If empty, it will try to use Workload Identity (run `gcloud auth application-default login`).
     # credentials: /tmp/credentials.json

--- a/examples/reports/gke.json
+++ b/examples/reports/gke.json
@@ -1,6 +1,6 @@
 {
   "id": "",
-  "timestamp": "0001-01-01T00:00:00Z",
+  "timestamp": "0002-01-01T00:00:00Z",
   "cluster": "",
   "package": "gke_basic",
   "name": "Google Kubernetes Engine basic checks",


### PR DESCRIPTION
`Location` works for both `Zones` and `Regions`.

Closes #9. 

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>