### PR TITLE
Include preflight-version, and package information in reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ DOCKER_IMAGE?=quay.io/jetstack/preflight
 DOCKER_IMAGE_TAG?=$(DOCKER_IMAGE):$(VERSION)
 
 define LDFLAGS
--X "github.com/jetstack/preflight/cmd.PreflightVersion=$(VERSION)" \
--X "github.com/jetstack/preflight/cmd.Platform=$(GOOS)/$(GOARCH)" \
--X "github.com/jetstack/preflight/cmd.Commit=$(COMMIT)" \
--X "github.com/jetstack/preflight/cmd.BuildDate=$(DATE)" \
--X "github.com/jetstack/preflight/cmd.GoVersion=$(GOVERSION)"
+-X "github.com/jetstack/preflight/pkg/version.PreflightVersion=$(VERSION)" \
+-X "github.com/jetstack/preflight/pkg/version.Platform=$(GOOS)/$(GOARCH)" \
+-X "github.com/jetstack/preflight/pkg/version.Commit=$(COMMIT)" \
+-X "github.com/jetstack/preflight/pkg/version.BuildDate=$(DATE)" \
+-X "github.com/jetstack/preflight/pkg/version.GoVersion=$(GOVERSION)"
 endef
 
 GO_BUILD:=go build -ldflags '$(LDFLAGS)'
@@ -40,7 +40,7 @@ lint: vet
 	cd $(ROOT_DIR) && golint
 
 ./builds/preflight-$(GOOS)-$(GOARCH):
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ./builds/preflight-$(GOOS)-$(GOARCH) .
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) -o ./builds/preflight-$(GOOS)-$(GOARCH) .
 
 build-all-platforms:
 	$(MAKE) GOOS=linux   GOARCH=amd64 ./builds/preflight-linux-amd64

--- a/api/report.go
+++ b/api/report.go
@@ -2,17 +2,32 @@ package api
 
 // Report contains the fields of a Preflight report
 type Report struct {
-	// Unique ID of the report
+	// Unique ID of the report.
 	ID string `json:"id"`
-	// Timestamp indicates when the report was generated
+	// PreflightVersion indicates the version of preflight this report was generated with.
+	PreflightVersion string `json:"preflight-version"`
+	// Timestamp indicates when the report was generated.
 	Timestamp Time `json:"timestamp"`
-	// Cluster indicates which was the target of the report
+	// Cluster indicates which was the target of the report.
 	Cluster string `json:"cluster"`
-	// Package indicates which package was used for the report
-	Package     string          `json:"package"`
-	Name        string          `json:"name"`
-	Description string          `json:"description,omitempty"`
-	Sections    []ReportSection `json:"sections,omitempty"`
+	// Package indicates which package was used for the report.
+	Package Package `json:"package"`
+	// Name is the name of the package that was used for this report.
+	Name string `json:"name"`
+	// Description is the description of the package that was used for this report.
+	Description string `json:"description,omitempty"`
+	// Sections contains the sections of the package that was used for this report.
+	Sections []ReportSection `json:"sections,omitempty"`
+}
+
+// Package contains all the details to identify a package.
+type Package struct {
+	// Namespace the package belongs to.
+	Namespace string `json:"namespace"`
+	// ID is the ID of the package.
+	ID string `json:"id"`
+	// Version is the version of the package.
+	Version string `json:"version"`
 }
 
 // ReportSection contains the fields of a section inside a Report

--- a/api/report.go
+++ b/api/report.go
@@ -13,7 +13,7 @@ type Report struct {
 	// Package indicates which package was used for the report. (deprecated)
 	Package string `json:"package"`
 	// PackageInformation contains all the information about the package that was used to generate the report.
-	PackageInformation Package `json:"package-information"`
+	PackageInformation PackageInformation `json:"package-information"`
 	// Name is the name of the package that was used for this report.
 	Name string `json:"name"`
 	// Description is the description of the package that was used for this report.
@@ -22,8 +22,8 @@ type Report struct {
 	Sections []ReportSection `json:"sections,omitempty"`
 }
 
-// Package contains all the details to identify a package.
-type Package struct {
+// PackageInformation contains all the details to identify a package.
+type PackageInformation struct {
 	// Namespace the package belongs to.
 	Namespace string `json:"namespace"`
 	// ID is the ID of the package.

--- a/api/report.go
+++ b/api/report.go
@@ -10,8 +10,10 @@ type Report struct {
 	Timestamp Time `json:"timestamp"`
 	// Cluster indicates which was the target of the report.
 	Cluster string `json:"cluster"`
-	// Package indicates which package was used for the report.
-	Package Package `json:"package"`
+	// Package indicates which package was used for the report. (deprecated)
+	Package string `json:"package"`
+	// PackageInformation contains all the information about the package that was used to generate the report.
+	PackageInformation Package `json:"package-information"`
 	// Name is the name of the package that was used for this report.
 	Name string `json:"name"`
 	// Description is the description of the package that was used for this report.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,23 +3,10 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/jetstack/preflight/pkg/version"
+
 	"github.com/spf13/cobra"
 )
-
-// PreflightVersion hosts the version of the app. It is injected at build time.
-var PreflightVersion = "development"
-
-// Commit is the commit hash of the build
-var Commit string
-
-// BuildDate is the date it was built
-var BuildDate string
-
-// GoVersion is the go version that was used to compile this
-var GoVersion string
-
-// Platform is the target platform this was compiled for
-var Platform string
 
 var verbose bool
 
@@ -29,12 +16,12 @@ var versionCmd = &cobra.Command{
 	Long: `Display preflight version.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Preflight version: ", PreflightVersion, Platform)
+		fmt.Println("Preflight version: ", version.PreflightVersion, version.Platform)
 		if verbose {
 			fmt.Println()
-			fmt.Println("Commit: ", Commit)
-			fmt.Println("Built: ", BuildDate)
-			fmt.Println("Go: ", GoVersion)
+			fmt.Println("Commit: ", version.Commit)
+			fmt.Println("Built: ", version.BuildDate)
+			fmt.Println("Go: ", version.GoVersion)
 		}
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gomarkdown/markdown v0.0.0-20191104174740-4d42851d4d5a
 	github.com/gookit/color v1.2.0
 	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/open-policy-agent/opa v0.15.0
 	github.com/pkg/errors v0.8.1
 	github.com/sergi/go-diff v1.0.0 // indirect
@@ -15,6 +16,7 @@ require (
 	github.com/spf13/viper v1.5.0
 	github.com/yudai/gojsondiff v1.0.0
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
+	github.com/yudai/pp v2.0.1+incompatible // indirect
 	golang.org/x/arch v0.0.0-20191126211547-368ea8f32fff // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,10 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.0-20181025052659-b20a3daf6a39/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -233,6 +237,8 @@ github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCO
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3IfnEUduWvb9is428/nNb5L3U01M=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
+github.com/yudai/pp v2.0.1+incompatible h1:Q4//iY4pNF6yPLZIigmvcl7k/bPgrcTPIFIcmawg5bI=
+github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
@@ -305,6 +311,7 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/exporter/json.go
+++ b/pkg/exporter/json.go
@@ -25,7 +25,8 @@ func (e *JSONExporter) Export(ctx context.Context, policyManifest *packaging.Pol
 	report := api.Report{
 		// TODO: we are omitting ID, Timestamp and Cluster for now, but it will get fixed with #1
 		PreflightVersion: version.PreflightVersion,
-		Package: api.Package{
+		Package:          policyManifest.ID,
+		PackageInformation: api.Package{
 			Namespace: policyManifest.Namespace,
 			ID:        policyManifest.ID,
 			Version:   policyManifest.PackageVersion,

--- a/pkg/exporter/json.go
+++ b/pkg/exporter/json.go
@@ -26,7 +26,7 @@ func (e *JSONExporter) Export(ctx context.Context, policyManifest *packaging.Pol
 		// TODO: we are omitting ID, Timestamp and Cluster for now, but it will get fixed with #1
 		PreflightVersion: version.PreflightVersion,
 		Package:          policyManifest.ID,
-		PackageInformation: api.Package{
+		PackageInformation: api.PackageInformation{
 			Namespace: policyManifest.Namespace,
 			ID:        policyManifest.ID,
 			Version:   policyManifest.PackageVersion,

--- a/pkg/exporter/json.go
+++ b/pkg/exporter/json.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jetstack/preflight/api"
 	"github.com/jetstack/preflight/pkg/packaging"
 	"github.com/jetstack/preflight/pkg/results"
+	"github.com/jetstack/preflight/pkg/version"
 )
 
 // JSONExporter is an Exporter that outputs the results enriched with metadata in a JSON format
@@ -23,7 +24,12 @@ func NewJSONExporter() *JSONExporter {
 func (e *JSONExporter) Export(ctx context.Context, policyManifest *packaging.PolicyManifest, intermediateJSON []byte, rc *results.ResultCollection) (*bytes.Buffer, error) {
 	report := api.Report{
 		// TODO: we are omitting ID, Timestamp and Cluster for now, but it will get fixed with #1
-		Package:     policyManifest.ID,
+		PreflightVersion: version.PreflightVersion,
+		Package: api.Package{
+			Namespace: policyManifest.Namespace,
+			ID:        policyManifest.ID,
+			Version:   policyManifest.PackageVersion,
+		},
 		Name:        policyManifest.Name,
 		Description: policyManifest.Description,
 		Sections:    make([]api.ReportSection, len(policyManifest.Sections)),

--- a/pkg/exporter/json_test.go
+++ b/pkg/exporter/json_test.go
@@ -14,9 +14,12 @@ import (
 
 func TestJSONExport(t *testing.T) {
 	pm := &packaging.PolicyManifest{
-		ID:          "test-pkg",
-		Name:        "Test Package",
-		Description: "This is a test package.",
+		SchemaVersion:  "1.0.0",
+		Namespace:      "test.org",
+		ID:             "test-pkg",
+		PackageVersion: "1.2.3",
+		Name:           "Test Package",
+		Description:    "This is a test package.",
 		Sections: []packaging.Section{
 			packaging.Section{
 				ID:          "section-1",
@@ -155,7 +158,12 @@ func TestJSONExport(t *testing.T) {
   ],
   "description": "This is a test package.",
   "name": "Test Package",
-  "package": "test-pkg",
+  "package": {
+    "id": "test-pkg",
+    "namespace": "test.org",
+    "version": "1.2.3"
+  },
+  "preflight-version": "development",
   "cluster": "",
   "timestamp": "0001-01-01T00:00:00Z",
   "id": ""

--- a/pkg/exporter/json_test.go
+++ b/pkg/exporter/json_test.go
@@ -158,7 +158,8 @@ func TestJSONExport(t *testing.T) {
   ],
   "description": "This is a test package.",
   "name": "Test Package",
-  "package": {
+  "package": "test-pkg",
+  "package-information": {
     "id": "test-pkg",
     "namespace": "test.org",
     "version": "1.2.3"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,18 @@
+package version
+
+// This variables are injected at build time.
+
+// PreflightVersion hosts the version of the app.
+var PreflightVersion = "development"
+
+// Commit is the commit hash of the build
+var Commit string
+
+// BuildDate is the date it was built
+var BuildDate string
+
+// GoVersion is the go version that was used to compile this
+var GoVersion string
+
+// Platform is the target platform this was compiled for
+var Platform string


### PR DESCRIPTION
This changes the `api.Report` schema to include both the version of Preflight that was used and also the additional information of the Package.

Notice this is a breaking change since we are mutating the existing `Package` property in the report to a `Package` object.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>