### PR TITLE
Add some more doc and add PackageInformation to ReportMetadata struct

### DIFF
--- a/api/report.go
+++ b/api/report.go
@@ -34,29 +34,50 @@ type PackageInformation struct {
 
 // ReportSection contains the fields of a section inside a Report
 type ReportSection struct {
-	ID          string       `json:"id"`
-	Name        string       `json:"name"`
-	Description string       `json:"description,omitempty"`
-	Rules       []ReportRule `json:"rules,omitempty"`
+	// ID is the ID of the section.
+	ID string `json:"id"`
+	// Name is the name of the section.
+	Name string `json:"name"`
+	// Description is the description of the section.
+	Description string `json:"description,omitempty"`
+	// Rules contain all the rules in the section.
+	Rules []ReportRule `json:"rules,omitempty"`
 }
 
 // ReportRule contains the fields of a rule inside a Report
 type ReportRule struct {
-	ID          string      `json:"id"`
-	Name        string      `json:"name"`
-	Description string      `json:"description,omitempty"`
-	Manual      bool        `json:"manual,omitempty"`
-	Remediation string      `json:"remediation,omitempty"`
-	Links       []string    `json:"links,omitempty"`
-	Success     bool        `json:"success"`
-	Value       interface{} `json:"value,omitempty"`
-	Missing     bool        `json:"missing"`
+	// ID is the id of the rule.
+	ID string `json:"id"`
+	// Name is a shortname for the rule.
+	Name string `json:"name"`
+	// Description is a text describing what the rule is about.
+	Description string `json:"description,omitempty"`
+	// Manual indicated whether the rule can be evaluated automatically by Preflight or requires manual intervention.
+	Manual bool `json:"manual,omitempty"`
+	// Remediation is a text describing how to fix a failure of the rule.
+	Remediation string `json:"remediation,omitempty"`
+	// Links contains useful links related to the rule.
+	Links []string `json:"links,omitempty"`
+	// Success indicates whether the check was a success or not.
+	Success bool `json:"success"`
+	// Value contains the raw result of the check.
+	Value interface{} `json:"value,omitempty"`
+	// Missing indicated wherer the REGO rule was missing or not.
+	Missing bool `json:"missing"`
 }
 
 // ReportMetadata contains metadata about a report
 type ReportMetadata struct {
-	Cluster   string `json:"cluster"`
-	Timestamp Time   `json:"timestamp"`
-	Package   string `json:"package"`
-	ID        string `json:"id"`
+	// Unique ID of the report.
+	ID string `json:"id"`
+	// Timestamp indicates when the report was generated.
+	Timestamp Time `json:"timestamp"`
+	// Cluster indicates which was the target of the report.
+	Cluster string `json:"cluster"`
+	// Package indicates which package was used for the report. (deprecated)
+	Package string `json:"package"`
+	// PackageInformation contains all the information about the package that was used to generate the report.
+	PackageInformation PackageInformation `json:"package-information"`
+	// PreflightVersion indicates the version of preflight this report was generated with.
+	PreflightVersion string `json:"preflight-version"`
 }


### PR DESCRIPTION
Adding some more documentation and also adding `PackagingInformation` to `ReportMetadata` for completeness.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>