### PR TITLE
Do not enforce numeric IDs and enforce RootQuery

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -29,8 +29,7 @@ The linter will check for common issues with packages:
 - That a correctly structured policy-manifest.yaml file is present
 - That at least one .rego file is present with OPA rules
 - That at least one .rego test file is present
-- That the rego files use the correct module name
-- That all rules and sections follow the correct naming scheme`,
+- That the rego files use the correct module name`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			// Fail if given no input

--- a/pkg/lint/manifest.go
+++ b/pkg/lint/manifest.go
@@ -111,16 +111,6 @@ func LintSection(manifestID string, section packaging.Section) []LintError {
 	if section.ID == "" {
 		lint("Section ID absent")
 	}
-	re := regexp.MustCompile(`^(\d+)\.(\d+)$`)
-	matches := re.FindStringSubmatch(section.ID)
-	if len(matches) != 3 {
-		lint("Malformed Section ID")
-	} else {
-		if matches[0] != section.ID {
-			lint("Incorrectly formatted Section ID")
-		}
-		// No need to check matches[2], the regex implicitly did so
-	}
 
 	if section.Name == "" {
 		lint("Section Name absent")
@@ -163,19 +153,6 @@ func LintRule(sectionID string, rule packaging.Rule) []LintError {
 
 	if rule.ID == "" {
 		lint("Rule ID absent")
-	}
-	re := regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)$`)
-	matches := re.FindStringSubmatch(rule.ID)
-	if len(matches) != 4 {
-		lint("Malformed Rule ID")
-	} else {
-		if matches[0] != rule.ID {
-			lint("Incorrectly formatted Rule ID")
-		}
-		if fmt.Sprintf("%s.%s", matches[1], matches[2]) != sectionID {
-			lint("Rule ID not decendant of Section ID")
-		}
-		// No need to check matches[3], the regex implicitly did so
 	}
 
 	if rule.Name == "" {

--- a/pkg/lint/manifest.go
+++ b/pkg/lint/manifest.go
@@ -36,6 +36,10 @@ func LintPolicyManifest(manifest packaging.PolicyManifest) []LintError {
 		lint("Manifest PackageVersion must be semver")
 	}
 
+	if manifest.RootQuery == "" {
+		lint("Manifest RootQuery absent")
+	}
+
 	sections := manifest.Sections
 	if len(sections) == 0 {
 		lint("No sections in manifest")

--- a/pkg/lint/manifest.go
+++ b/pkg/lint/manifest.go
@@ -116,6 +116,12 @@ func LintSection(manifestID string, section packaging.Section) []LintError {
 		lint("Section ID absent")
 	}
 
+	// section IDs should follow the same syntax as rules IDs
+	match, _ := regexp.MatchString(`^[_a-zA-Z][_a-zA-Z0-9]*$`, section.ID)
+	if !match {
+		lint("Malformed section ID: it should only contain alphanumeric characters and underscores and it should not start with a number.")
+	}
+
 	if section.Name == "" {
 		lint("Section Name absent")
 	}
@@ -157,6 +163,12 @@ func LintRule(sectionID string, rule packaging.Rule) []LintError {
 
 	if rule.ID == "" {
 		lint("Rule ID absent")
+	}
+
+	// rule IDs should follow Rego grammar: https://www.openpolicyagent.org/docs/latest/policy-reference/#grammar
+	match, _ := regexp.MatchString(`^[_a-zA-Z][_a-zA-Z0-9]*$`, rule.ID)
+	if !match {
+		lint("Malformed rule ID: it should only contain alphanumeric characters and underscores and it should not start with a number.")
 	}
 
 	if rule.Name == "" {

--- a/pkg/lint/manifest.go
+++ b/pkg/lint/manifest.go
@@ -105,6 +105,7 @@ func LintPolicyManifest(manifest packaging.PolicyManifest) []LintError {
 	return lints
 }
 
+// LintSection lints a section of the policy manifest.
 func LintSection(manifestID string, section packaging.Section) []LintError {
 	lints := make([]LintError, 0)
 
@@ -154,6 +155,7 @@ func LintSection(manifestID string, section packaging.Section) []LintError {
 	return lints
 }
 
+// LintRule lints a rule of the policy manifest.
 func LintRule(sectionID string, rule packaging.Rule) []LintError {
 	lints := make([]LintError, 0)
 

--- a/pkg/lint/manifest_test.go
+++ b/pkg/lint/manifest_test.go
@@ -174,6 +174,7 @@ func TestLintPolicyManifestSuccess(t *testing.T) {
 		ID:             "mypackage",
 		Namespace:      "mynamespace",
 		Name:           "My Package",
+		RootQuery:      "data.pods",
 		PackageVersion: "1.0.0",
 		Sections: []packaging.Section{
 			{
@@ -216,6 +217,15 @@ var invalidManifests = []struct {
 	{
 		name:         "No ID",
 		expectedLint: "Manifest ID absent",
+		manifest: packaging.PolicyManifest{
+			SchemaVersion:  "1.0.0",
+			Name:           "My Package",
+			PackageVersion: "1.0.0",
+		},
+	},
+	{
+		name:         "No RootQuery",
+		expectedLint: "Manifest RootQuery absent",
 		manifest: packaging.PolicyManifest{
 			SchemaVersion:  "1.0.0",
 			Name:           "My Package",

--- a/pkg/lint/manifest_test.go
+++ b/pkg/lint/manifest_test.go
@@ -18,26 +18,6 @@ var invalidRules = []struct {
 		expectedLint: "Rule ID absent",
 	},
 	{
-		name:         "Non-numeric rule ID",
-		rule:         packaging.Rule{ID: "1.4.c"},
-		expectedLint: "Malformed Rule ID",
-	},
-	{
-		name:         "Rule ID too short",
-		rule:         packaging.Rule{ID: "1.4"},
-		expectedLint: "Malformed Rule ID",
-	},
-	{
-		name:         "Rule ID too long",
-		rule:         packaging.Rule{ID: "1.4.3.6"},
-		expectedLint: "Malformed Rule ID",
-	},
-	{
-		name:         "Rule ID not decendant",
-		rule:         packaging.Rule{ID: "1.5.1"},
-		expectedLint: "Rule ID not decendant of Section ID",
-	},
-	{
 		name:         "Rule Name absent",
 		rule:         packaging.Rule{},
 		expectedLint: "Rule Name absent",
@@ -132,27 +112,6 @@ var invalidSections = []struct {
 		expectedLint: "Section ID absent",
 		section: packaging.Section{
 			Name: "My Section",
-		},
-	},
-	{
-		name:         "Non-numeric ID",
-		expectedLint: "Malformed Section ID",
-		section: packaging.Section{
-			ID: "1.a",
-		},
-	},
-	{
-		name:         "Section ID too short",
-		expectedLint: "Malformed Section ID",
-		section: packaging.Section{
-			ID: "1",
-		},
-	},
-	{
-		name:         "Section ID too long",
-		expectedLint: "Malformed Section ID",
-		section: packaging.Section{
-			ID: "1.4.3",
 		},
 	},
 	{

--- a/pkg/lint/manifest_test.go
+++ b/pkg/lint/manifest_test.go
@@ -18,6 +18,16 @@ var invalidRules = []struct {
 		expectedLint: "Rule ID absent",
 	},
 	{
+		name:         "Starting with a number",
+		rule:         packaging.Rule{ID: "1_a"},
+		expectedLint: "Malformed rule ID",
+	},
+	{
+		name:         "Containing not allowed characters",
+		rule:         packaging.Rule{ID: "a.1"},
+		expectedLint: "Malformed rule ID",
+	},
+	{
 		name:         "Rule Name absent",
 		rule:         packaging.Rule{},
 		expectedLint: "Rule Name absent",
@@ -33,16 +43,17 @@ func TestLintRule(t *testing.T) {
 				lints := LintRule(sectionID, ruleCase.rule)
 				var containsExpectedLint = false
 				for _, l := range lints {
-					if l.Lint == ruleCase.expectedLint {
+					if strings.HasPrefix(l.Lint, ruleCase.expectedLint) {
 						containsExpectedLint = true
 						break
 					}
 				}
 				if !containsExpectedLint {
 					t.Errorf(
-						"Expected rule %#v to produce lint '%s', but it didn't.",
+						"Expected rule %#v to produce lint '%s', but it didn't. Got %v",
 						ruleCase.rule,
 						ruleCase.expectedLint,
+						lints,
 					)
 				}
 			})
@@ -51,7 +62,7 @@ func TestLintRule(t *testing.T) {
 
 func TestLintRuleSuccess(t *testing.T) {
 	validRule := packaging.Rule{
-		ID:   "1.2.3",
+		ID:   "_1_B2_a3",
 		Name: "My Rule",
 	}
 	sectionID := "1.2"
@@ -67,11 +78,11 @@ func TestLintRuleSuccess(t *testing.T) {
 
 func TestLintSectionSuccess(t *testing.T) {
 	validSection := packaging.Section{
-		ID:   "1.4",
+		ID:   "_1_4",
 		Name: "My section",
 		Rules: []packaging.Rule{
 			packaging.Rule{
-				ID:   "1.4.1",
+				ID:   "_1_B2_a3",
 				Name: "My Rule",
 			},
 		},
@@ -115,6 +126,16 @@ var invalidSections = []struct {
 		},
 	},
 	{
+		name:         "Starting with a number",
+		expectedLint: "Malformed section ID",
+		section:      packaging.Section{ID: "1_a"},
+	},
+	{
+		name:         "Containing not allowed characters",
+		expectedLint: "Malformed section ID",
+		section:      packaging.Section{ID: "a.1"},
+	},
+	{
 		name:         "Duplicate rule ID",
 		expectedLint: "Rule ID 1.4.1 duplicated 2 times",
 		section: packaging.Section{
@@ -146,7 +167,7 @@ func TestSectionLint(t *testing.T) {
 				)
 				var containsExpectedLint = false
 				for _, l := range lints {
-					if l.Lint == sectionCase.expectedLint {
+					if strings.HasPrefix(l.Lint, sectionCase.expectedLint) {
 						containsExpectedLint = true
 						break
 					}
@@ -178,11 +199,11 @@ func TestLintPolicyManifestSuccess(t *testing.T) {
 		PackageVersion: "1.0.0",
 		Sections: []packaging.Section{
 			{
-				ID:   "1.2",
+				ID:   "a_section",
 				Name: "My section",
 				Rules: []packaging.Rule{
 					{
-						ID:   "1.2.3",
+						ID:   "a_rule",
 						Name: "My Rule",
 					},
 				},


### PR DESCRIPTION
Numeric IDs are very artificial and not meaningful at all.

I wouldn't enforce them in the linter.

Also, the linter wasn't enforcing RootQuery, but it is mandatory.