### PR TITLE
Update GKE basic package

### DIFF
--- a/preflight-packages/examples.jetstack.io/gke_basic/gke_test.rego
+++ b/preflight-packages/examples.jetstack.io/gke_basic/gke_test.rego
@@ -9,167 +9,268 @@ assert_allowed(output) = output {
 assert_violates(output, messages) = output {
 	trace(sprintf("GOT: %s", [concat(",", output)]))
 	trace(sprintf("WANT: %s", [concat(",", messages)]))
-
 	output == messages
 }
 
 cluster(x) = y { y := {"gke": {"Cluster": x }} }
 
-# Rule 'private_cluster'
-test_private_cluster_private_cluster_private_nodes_enabled {
-	output := preflight_private_cluster with input as
-		cluster({"privateClusterConfig":{"enablePrivateNodes": true}})
+# Networking
 
+# Private cluster enabled
+test_private_cluster_enabled_private_cluster_private_nodes_enabled {
+	output := private_cluster_enabled with input as cluster(
+		{
+			"privateClusterConfig": {
+				"enablePrivateNodes": true
+			}
+		}
+	)
 	assert_allowed(output)
 }
-test_private_cluster_private_cluster_private_nodes_not_enabled {
-	output := preflight_private_cluster with input as
-		cluster({"privateClusterConfig":{"enablePrivateNodes": false}})
-
-	assert_violates(output, {
-		"cluster does not have private nodes enabled"
-		})
+test_private_cluster_enabled_private_cluster_private_nodes_not_enabled {
+	output := private_cluster_enabled with input as cluster(
+		{
+			"privateClusterConfig": {
+				"enablePrivateNodes": false
+			}
+		}
+	)
+	assert_violates(output,
+		{
+			"private cluster has not been enabled"
+		}
+	)
 }
-test_private_cluster_private_cluster_private_nodes_not_set {
-	output := preflight_private_cluster with input as cluster({"privateClusterConfig":{}})
-	assert_violates(output, {
-		"cluster does not have private nodes enabled"
-		})
+test_private_cluster_enabled_private_cluster_private_nodes_not_set {
+	output := private_cluster_enabled with input as cluster(
+		{
+			"privateClusterConfig": {}
+		}
+	)
+	assert_violates(output,
+		{
+			"private cluster has not been enabled"
+		}
+	)
 }
 
-# Rule 'basic_auth_disabled'
-test_basic_auth_disabled_no_username_and_password {
-	output := preflight_basic_auth_disabled with input as cluster({"masterAuth":{}})
+# Authentication
+
+# Basic authentication disabled
+test_basic_authentication_disabled_no_username_and_password {
+	output := basic_authentication_disabled with input as cluster(
+		{
+			"masterAuth": {}
+		}
+	)
 	assert_allowed(output)
 }
-test_basic_auth_disabled_no_master_auth {
-	output := preflight_basic_auth_disabled with input as cluster({})
+test_basic_authentication_disabled_no_master_auth {
+	output := basic_authentication_disabled with input as cluster(
+		{}
+	)
 	assert_allowed(output)
 }
-test_basic_auth_disabled_username_and_password {
-	output := preflight_basic_auth_disabled with input as
-		cluster({"masterAuth":{"username": "foo", "password": "foobar"}})
+test_basic_authentication_disabled_username_and_password {
+	output := basic_authentication_disabled with input as cluster(
+		{
+			"masterAuth": {
+				"username": "foo",
+				"password": "foobar"
+			}
+		}
+	)
+	assert_violates(output,
 
-	assert_violates(output, {
-		"cluster does not have basic auth disabled"
-		})
+		{
+			"basic authentication is enabled with username 'foo'",
+			"basic authentication is enabled"
+		}
+	)
 }
-test_basic_auth_disabled_username_only {
-	output := preflight_basic_auth_disabled with input as
-		cluster({"masterAuth":{"username": "foo"}})
-
-	assert_violates(output, {
-		"cluster does not have basic auth disabled"
-		})
+test_basic_authentication_disabled_username_only {
+	output := basic_authentication_disabled with input as cluster(
+		{
+			"masterAuth": {
+				"username": "foo"
+			}
+		}
+	)
+	assert_violates(output,
+		{
+			"basic authentication is enabled with username 'foo'"
+		}
+	)
 }
-test_basic_auth_disabled_password_only {
-	output := preflight_basic_auth_disabled with input as
-		cluster({"masterAuth":{"password": "foobar"}})
-
-	assert_violates(output, {
-		"cluster does not have basic auth disabled"
-		})
+test_basic_authentication_disabled_password_only {
+	output := basic_authentication_disabled with input as cluster(
+		{
+			"masterAuth": {
+				"password": "foobar"
+			}
+		}
+	)
+	assert_violates(output,
+		{
+			"basic authentication is enabled"
+		}
+	)
 }
 
-# Rule 'abac_disabled'
-test_abac_disabled_legacy_abac_enabled {
-	output := preflight_abac_disabled with input as
-		cluster({"legacyAbac":{"enabled": true}})
-
-	assert_violates(output, {
-		"cluster has legacy abac enabled"
-		})
+# Legacy ABAC disabled
+test_legacy_abac_disabled_legacy_abac_enabled {
+	output := legacy_abac_disabled with input as cluster(
+		{
+			"legacyAbac": {
+				"enabled": true
+			}
+		}
+	)
+	assert_violates(output,
+		{
+			"legacy ABAC is enabled"
+		}
+	)
 }
-test_abac_disabled_legacy_abac_disabled {
-	output := preflight_abac_disabled with input as
-		cluster({"legacyAbac":{"enabled": false}})
-
+test_legacy_abac_disabled_legacy_abac_disabled {
+	output := legacy_abac_disabled with input as cluster(
+		{
+			"legacyAbac": {
+				"enabled": false
+			}
+		}
+	)
 	assert_allowed(output)
 }
-test_abac_disabled_legacy_abac_empty {
-	output := preflight_abac_disabled with input as cluster({"legacyAbac":{}})
-
+test_legacy_abac_disabled_legacy_abac_empty {
+	output := legacy_abac_disabled with input as cluster(
+		{
+			"legacyAbac": {}
+		}
+	)
 	assert_allowed(output)
 }
-test_abac_disabled_legacy_abac_missing {
-	output := preflight_abac_disabled with input as cluster({})
-
-	assert_allowed(output)
-}
-
-# Rule 'k8s_master_up_to_date'
-test_k8s_master_up_to_date_empty_kubernetes_version {
-	output :=  preflight_k8s_master_up_to_date with input as
-		cluster({"currentMasterVersion": ""})
-
-	assert_violates(output, {
-		"cluster master is not up to date"
-		})
-}
-test_k8s_master_up_to_date_ancient_kubernetes_version {
-	output := preflight_k8s_master_up_to_date with input as
-		cluster({"currentMasterVersion": "1.11.9-gke.5"})
-
-	assert_violates(output, {
-		"cluster master is not up to date"
-		})
-}
-test_k8s_master_up_to_date_modern_kubernetes_version {
-	output := preflight_k8s_master_up_to_date with input as
-		cluster({"currentMasterVersion": "1.13.6-gke.13"})
-
+test_legacy_abac_disabled_legacy_abac_missing {
+	output := legacy_abac_disabled with input as cluster(
+		{}
+	)
 	assert_allowed(output)
 }
 
-# Rule 'k8s_nodes_up_to_date'
-test_k8s_nodes_up_to_date_no_node_pools {
-	output := preflight_k8s_nodes_up_to_date with input as
-		cluster({"nodePools":[]})
+# Maintainance
+
+# Kubernetes node version up to date
+test_kubernetes_node_version_up_to_date_no_node_pools {
+	output := kubernetes_node_version_up_to_date with input as cluster(
+		{
+			"nodePools": []
+		}
+	)
 	assert_allowed(output)
 }
-test_k8s_nodes_up_to_date_pool_no_version {
-	output := preflight_k8s_nodes_up_to_date with input as
-		cluster({ "nodePools":[{"name": "test-pool"}]})
-
-	assert_violates(output, {
-		"cluster node pool 'test-pool' has no version"
-		})
+test_kubernetes_node_version_up_to_date_pool_no_version {
+	output := kubernetes_node_version_up_to_date with input as cluster(
+		{
+			"nodePools": [
+				{
+					"name": "test-pool"
+				}
+			]
+		}
+	)
+	assert_violates(output,
+		{
+			"node pool 'test-pool' version is missing"
+		}
+	)
 }
-test_k8s_nodes_up_to_date_old_version {
-	output := preflight_k8s_nodes_up_to_date with input as
-		cluster({"nodePools":[
-			{"name": "test-pool", "version": "1.11.9-gke.5"}
-		]})
-
-	assert_violates(output, {
-		"cluster node pool 'test-pool' is outdated"
-		})
+test_kubernetes_node_version_up_to_date_old_version {
+	output := kubernetes_node_version_up_to_date with input as cluster(
+		{
+			"nodePools": [
+				{
+					"name": "test-pool",
+					"version": "1.11.9-gke.5"
+				}
+			]
+		}
+	)
+	assert_violates(output,
+		{
+			"node pool 'test-pool' current version '1.11.9-gke.5' not up to date"
+		}
+	)
 }
-test_k8s_nodes_up_to_date_modern_version {
-	output := preflight_k8s_nodes_up_to_date with input as
-		cluster({"nodePools":[
-			{"name": "test-pool", "version": "1.13.6-gke.13"}
-		]})
-
+test_kubernetes_node_version_up_to_date_up_to_date_version {
+	output := kubernetes_node_version_up_to_date with input as cluster(
+		{
+			"nodePools": [
+				{
+					"name": "test-pool",
+					"version": "1.13.6-gke.13"
+				}
+			]
+		}
+	)
 	assert_allowed(output)
 }
-test_k8s_nodes_up_to_date_multiple_pools_some_incorrect {
-	output := preflight_k8s_nodes_up_to_date with input as
-		cluster({"nodePools":[
-			{"name": "test-pool-1", "version": "1.13.6-gke.13"},
-			{"name": "test-pool-2","version": "1.11.9-gke.5"}
-		]})
-
-	assert_violates(output, {
-		"cluster node pool 'test-pool-2' is outdated"
-		})
+test_kubernetes_node_version_up_to_date_multiple_pools_some_old {
+	output := kubernetes_node_version_up_to_date with input as cluster(
+		{
+			"nodePools": [
+				{
+					"name": "test-pool-1",
+					"version": "1.13.6-gke.13"
+				},
+				{
+					"name": "test-pool-2",
+					"version": "1.11.9-gke.5"
+				}
+			]
+		}
+	)
+	assert_violates(output,
+		{
+			"node pool 'test-pool-2' current version '1.11.9-gke.5' not up to date"
+		}
+	)
 }
-test_k8s_nodes_up_to_date_multiple_pools_all_correct {
-	output := preflight_k8s_nodes_up_to_date with input as
-		cluster({"nodePools":[
-			{"name": "test-pool-1", "version": "1.13.6-gke.13"},
-			{"name": "test-pool-2","version": "1.13.6-gke.13"}
-		]})
-
+test_kubernetes_node_version_up_to_date_multiple_pools_all_old {
+	output := kubernetes_node_version_up_to_date with input as cluster(
+		{
+			"nodePools": [
+				{
+					"name": "test-pool-1",
+					"version": "1.11.9-gke.5"
+				},
+				{
+					"name": "test-pool-2",
+					"version": "1.11.9-gke.5"
+				}
+			]
+		}
+	)
+	assert_violates(output,
+		{
+			"node pool 'test-pool-1' current version '1.11.9-gke.5' not up to date",
+			"node pool 'test-pool-2' current version '1.11.9-gke.5' not up to date"
+		}
+	)
+}
+test_kubernetes_node_version_up_to_date_multiple_pools_all_up_to_date {
+	output := kubernetes_node_version_up_to_date with input as cluster(
+		{
+			"nodePools": [
+				{
+					"name": "test-pool-1",
+					"version": "1.13.6-gke.13"
+				},
+				{
+					"name": "test-pool-2",
+					"version": "1.13.6-gke.13"
+				}
+			]
+		}
+	)
 	assert_allowed(output)
 }

--- a/preflight-packages/examples.jetstack.io/gke_basic/policy-manifest.yaml
+++ b/preflight-packages/examples.jetstack.io/gke_basic/policy-manifest.yaml
@@ -14,7 +14,7 @@ sections:
 - id: "networking"
   name: Networking
   rules:
-  - id: "private_cluster"
+  - id: private_cluster_enabled
     name: Private cluster enabled
     description: >
       Enabling private cluster means Nodes do not have public IP addresses, and
@@ -29,7 +29,7 @@ sections:
 - id: "authentication"
   name: Authentication
   rules:
-  - id: "basic_auth_disabled"
+  - id: basic_authentication_disabled
     name: Basic authentication disabled
     description: >
       Basic authentication allows a static plain-text username and password to
@@ -41,7 +41,7 @@ sections:
       authentication method immediately.
     links:
     - "https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#disable_basic_auth"
-  - id: "abac_disabled"
+  - id: legacy_abac_disabled
     name: Legacy ABAC disabled
     description: >
       Attribute Based Access Control (ABAC) should be disabled as it has been
@@ -58,7 +58,7 @@ sections:
 - id: "maintenance"
   name: Maintenance
   rules:
-  - id: "k8s_master_up_to_date"
+  - id: Kubernetes_master_version_up_to_date
     name: Kubernetes master version up to date
     description: >
       Kubernetes versions older than 1.13 no longer receive any patch updates
@@ -71,7 +71,7 @@ sections:
       zonal clusters, then upgrades will cause master downtime.
     links:
     - "https://cloud.google.com/kubernetes-engine/versioning-and-upgrades"
-  - id: "k8s_nodes_up_to_date"
+  - id: kubernetes_node_version_up_to_date
     name: Kubernetes node version up to date
     description: >
       Kubernetes versions older than 1.13 no longer receive any patch updates

--- a/preflight-packages/examples.jetstack.io/gke_basic/policy-manifest.yaml
+++ b/preflight-packages/examples.jetstack.io/gke_basic/policy-manifest.yaml
@@ -1,4 +1,4 @@
-schema-version: "0.1.0"
+schema-version: "0.1.1"
 id: "gke_basic"
 namespace: "examples.jetstack.io"
 package-version: "1.0.0"


### PR DESCRIPTION
This PR updates the GKE basic package to remove the `preflight_` prefix from rules and match its rules with the corresponding rules in the more comprehensive private GKE package.

Related to #27.

Signed-off-by: wwwil <wwwil.squires@gmail.com>