### PR TITLE
Handle the existence or not of the `preflight_` prefix in rego

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/storage v1.4.0
 	github.com/Azure/aks-engine v0.43.1
 	github.com/aws/aws-sdk-go v1.25.30
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/gomarkdown/markdown v0.0.0-20191104174740-4d42851d4d5a
 	github.com/gookit/color v1.2.0
 	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,7 @@ github.com/hashicorp/vault v0.11.5/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bA
 github.com/hashicorp/vault-plugin-secrets-kv v0.0.0-20181106190520-2236f141171e/go.mod h1:VJHHT2SC1tAPrfENQeBhLlb5FbZoKZM+oC/ROmEftz0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -305,9 +306,11 @@ github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzR
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.0-20181025052659-b20a3daf6a39/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -351,9 +354,11 @@ github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/open-policy-agent/opa v0.16.0 h1:VGyBInxJkrbZ2yNBGygnevnQFJgf/18ZbohvH7Xu9dw=
 github.com/open-policy-agent/opa v0.16.0/go.mod h1:P0xUE/GQAAgnvV537GzA0Ikw4+icPELRT327QJPkaKY=
@@ -463,6 +468,7 @@ github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCO
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3IfnEUduWvb9is428/nNb5L3U01M=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
+github.com/yudai/pp v2.0.1+incompatible h1:Q4//iY4pNF6yPLZIigmvcl7k/bPgrcTPIFIcmawg5bI=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -630,6 +636,7 @@ gopkg.in/asn1-ber.v1 v1.0.0-20170511165959-379148ca0225/go.mod h1:cuepJuh7vyXfUy
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.25.0 h1:Q3c4LgUofOEtz0wCE18Q2qwDkATLHLBUOmTvqjNCWkM=
@@ -644,6 +651,7 @@ gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5/go.mod h1:hiOFpYm0ZJb
 gopkg.in/src-d/go-billy.v4 v4.2.1/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd38aARFk=
 gopkg.in/src-d/go-git-fixtures.v3 v3.1.1/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
 gopkg.in/src-d/go-git.v4 v4.8.1/go.mod h1:Vtut8izDyrM8BUVQnzJ+YvmNcem2J89EmfZYCkLokZk=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/vmihailenco/msgpack.v2 v2.9.1/go.mod h1:/3Dn1Npt9+MYyLpYYXjInO/5jvMLamn+AEGwNEOatn8=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -32,9 +32,13 @@ const (
 )
 
 func ruleToResult(ruleID string) string {
-	return fmt.Sprintf("preflight_%s", strings.ReplaceAll(ruleID, ".", "_"))
+	return strings.ReplaceAll(ruleID, ".", "_")
 }
 
 func resultToRule(resultID string) string {
-	return strings.TrimPrefix(strings.ReplaceAll(resultID, "_", "."), "preflight.")
+	return strings.ReplaceAll(resultID, "_", ".")
+}
+
+func legacyRuleToResult(ruleID string) string {
+	return fmt.Sprintf("preflight_%s", strings.ReplaceAll(ruleID, ".", "_"))
 }

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestRuleToResult(t *testing.T) {
-	rule := "1.2.3"
-	expectedResult := "preflight_1_2_3"
+	rule := "something_1.2.3"
+	expectedResult := "something_1_2_3"
 	if ruleToResult(rule) != expectedResult {
 		t.Errorf(
 			"Expected rule %q to render as result %q, but got %q",
@@ -17,9 +17,22 @@ func TestRuleToResult(t *testing.T) {
 	}
 }
 
+func TestLegacyRuleToResult(t *testing.T) {
+	rule := "1.2.3"
+	expectedResult := "preflight_1_2_3"
+	if legacyRuleToResult(rule) != expectedResult {
+		t.Errorf(
+			"Expected rule %q to render as result %q, but got %q",
+			rule,
+			expectedResult,
+			ruleToResult(rule),
+		)
+	}
+}
+
 func TestResultToRule(t *testing.T) {
-	result := "preflight_1_3_3"
-	expectedRule := "1.3.3"
+	result := "something_1_3_3"
+	expectedRule := "something.1.3.3"
 	if resultToRule(result) != expectedRule {
 		t.Errorf(
 			"Expected result %q to render as rule %q, but got %q",

--- a/pkg/exporter/json.go
+++ b/pkg/exporter/json.go
@@ -50,6 +50,18 @@ func (e *JSONExporter) Export(ctx context.Context, policyManifest *packaging.Pol
 
 			results := rc.ByID()
 			result := results[ruleToResult(rule.ID)]
+
+			if result == nil {
+				supportsPrefix, err := policyManifest.SupportsPreflightPrefix()
+				if err != nil {
+					return nil, err
+				}
+
+				if supportsPrefix {
+					result = results[legacyRuleToResult(rule.ID)]
+				}
+			}
+
 			var value interface{}
 			violations := []string{}
 			success := false

--- a/pkg/exporter/json_test.go
+++ b/pkg/exporter/json_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestJSONExport(t *testing.T) {
 	pm := &packaging.PolicyManifest{
-		SchemaVersion:  "0.1.0",
+		SchemaVersion:  "0.1.1",
 		Namespace:      "test.org",
 		ID:             "test-pkg",
 		PackageVersion: "1.2.3",
@@ -39,6 +39,17 @@ func TestJSONExport(t *testing.T) {
 					},
 					packaging.Rule{
 						ID:          "r2",
+						Name:        "Another rule",
+						Description: "This is another rule.",
+						Manual:      false,
+						Remediation: "No remedy.",
+						Links: []string{
+							"http://jetstack.io/docs",
+							"http://jetstack.io/docs2",
+						},
+					},
+					packaging.Rule{
+						ID:          "r3",
 						Name:        "Another rule",
 						Description: "This is another rule.",
 						Manual:      false,
@@ -76,6 +87,168 @@ func TestJSONExport(t *testing.T) {
 	rc := &results.ResultCollection{
 		&results.Result{ID: ruleToResult("r1"), Violations: []string{}},
 		&results.Result{ID: ruleToResult("r2"), Violations: []string{"violation"}},
+		&results.Result{ID: "preflight_r3", Violations: []string{"another violation"}},
+	}
+
+	expectedJSON := `{
+  "sections": [
+    {
+      "rules": [
+        {
+          "missing": false,
+          "success": true,
+          "violations": [],
+          "links": [
+            "http://jetstack.io/docs",
+            "http://jetstack.io/docs2"
+          ],
+          "remediation": "No remedy.",
+          "description": "This is a rule.",
+          "name": "A rule",
+          "id": "r1"
+        },
+        {
+          "missing": false,
+          "success": false,
+          "violations": [
+            "violation"
+          ],
+          "links": [
+            "http://jetstack.io/docs",
+            "http://jetstack.io/docs2"
+          ],
+          "remediation": "No remedy.",
+          "description": "This is another rule.",
+          "name": "Another rule",
+          "id": "r2"
+        },
+        {
+          "missing": true,
+          "success": false,
+          "violations": [],
+          "links": [
+            "http://jetstack.io/docs",
+            "http://jetstack.io/docs2"
+          ],
+          "remediation": "No remedy.",
+          "description": "This is another rule.",
+          "name": "Another rule",
+          "id": "r3"
+        }
+      ],
+      "description": "This is a section.",
+      "name": "Sample section",
+      "id": "section-1"
+    },
+    {
+      "rules": [
+        {
+          "missing": true,
+          "success": false,
+          "violations": [],
+          "links": [
+            "http://jetstack.io/docs",
+            "http://jetstack.io/docs2"
+          ],
+          "remediation": "No remedy.",
+          "description": "This is another rule.",
+          "name": "Another rule",
+          "id": "r4"
+        }
+      ],
+      "description": "This is another section.",
+      "name": "Sample section 2",
+      "id": "section-2"
+    }
+  ],
+  "description": "This is a test package.",
+  "name": "Test Package",
+  "package": "test-pkg",
+  "package-information": {
+    "id": "test-pkg",
+    "namespace": "test.org",
+    "version": "1.2.3"
+  },
+  "preflight-version": "development",
+  "cluster": "",
+  "timestamp": "0001-01-01T00:00:00Z",
+  "id": ""
+}`
+
+	buf, err := jsonExporter.Export(context.Background(), pm, nil, rc)
+	if err != nil {
+		t.Fatalf("unexpected err: %+v", err)
+	}
+
+	var got, want map[string]interface{}
+
+	if err = json.Unmarshal([]byte(expectedJSON), &want); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if err = json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	diff := gojsondiff.New().CompareObjects(want, got)
+
+	if diff.Modified() {
+		f := formatter.NewAsciiFormatter(want, formatter.AsciiFormatterConfig{ShowArrayIndex: true, Coloring: true})
+		differences, err := f.Format(diff)
+		if err != nil {
+			t.Errorf("could not format diff: %+v", err)
+		}
+
+		t.Fatalf("got != want: %v", differences)
+	}
+}
+
+func TestJSONExportBackwardsCompatibility(t *testing.T) {
+	pm := &packaging.PolicyManifest{
+		SchemaVersion:  "0.1.0",
+		Namespace:      "test.org",
+		ID:             "test-pkg",
+		PackageVersion: "1.2.3",
+		Name:           "Test Package",
+		Description:    "This is a test package.",
+		Sections: []packaging.Section{
+			packaging.Section{
+				ID:          "section-1",
+				Name:        "Sample section",
+				Description: "This is a section.",
+				Rules: []packaging.Rule{
+					packaging.Rule{
+						ID:          "r1",
+						Name:        "A rule",
+						Description: "This is a rule.",
+						Manual:      false,
+						Remediation: "No remedy.",
+						Links: []string{
+							"http://jetstack.io/docs",
+							"http://jetstack.io/docs2",
+						},
+					},
+					packaging.Rule{
+						ID:          "r2",
+						Name:        "Another rule",
+						Description: "This is another rule.",
+						Manual:      false,
+						Remediation: "No remedy.",
+						Links: []string{
+							"http://jetstack.io/docs",
+							"http://jetstack.io/docs2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jsonExporter := JSONExporter{}
+
+	rc := &results.ResultCollection{
+		&results.Result{ID: ruleToResult("r1"), Violations: []string{}},
+		&results.Result{ID: legacyRuleToResult("r2"), Violations: []string{"violation"}},
 	}
 
 	expectedJSON := `{
@@ -114,26 +287,6 @@ func TestJSONExport(t *testing.T) {
       "description": "This is a section.",
       "name": "Sample section",
       "id": "section-1"
-    },
-    {
-      "rules": [
-        {
-          "missing": true,
-          "success": false,
-          "violations": [],
-          "links": [
-            "http://jetstack.io/docs",
-            "http://jetstack.io/docs2"
-          ],
-          "remediation": "No remedy.",
-          "description": "This is another rule.",
-          "name": "Another rule",
-          "id": "r4"
-        }
-      ],
-      "description": "This is another section.",
-      "name": "Sample section 2",
-      "id": "section-2"
     }
   ],
   "description": "This is a test package.",

--- a/pkg/packaging/versioning.go
+++ b/pkg/packaging/versioning.go
@@ -1,0 +1,23 @@
+package packaging
+
+import "github.com/blang/semver"
+
+// SupportsPreflightPrefix returns true if the SchemaVersion used supports rego rules with `preflight_` prefix over the IDs in the policy manifest. That behaviour was deprecated.
+func (m *PolicyManifest) SupportsPreflightPrefix() (bool, error) {
+	// If version is not defined, it is an old package.
+	if m.SchemaVersion == "" {
+		return true, nil
+	}
+
+	v010, err := semver.Make("0.1.0")
+	if err != nil {
+		panic(err)
+	}
+
+	v, err := semver.Make(m.SchemaVersion)
+	if err != nil {
+		return false, err
+	}
+
+	return v.LTE(v010), nil
+}

--- a/pkg/packaging/versioning_test.go
+++ b/pkg/packaging/versioning_test.go
@@ -1,0 +1,35 @@
+package packaging
+
+import "testing"
+
+func TestSupportsPreflightPrefix(t *testing.T) {
+	testCases := []struct {
+		version    string
+		wantResult bool
+		wantErr    bool
+	}{
+		{"", true, false},
+		{"0.0.1", true, false},
+		{"0.1.0", true, false},
+		{"0.1.1", false, false},
+		{"1.0.0", false, false},
+		{"not-semver", false, true},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(string(idx), func(t *testing.T) {
+			m := &PolicyManifest{SchemaVersion: tc.version}
+			gotResult, err := m.SupportsPreflightPrefix()
+
+			if err != nil && !tc.wantErr {
+				t.Fatalf("expected error to be nil but got: %+v", err)
+			} else if err == nil && tc.wantErr {
+				t.Fatalf("expected to get an error but didn't get one")
+			}
+
+			if gotResult != tc.wantResult {
+				t.Errorf("expected %s to have compatibility=%v but got compatibility=%v", tc.version, tc.wantResult, gotResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This allows the `preflight_` to exist or not if the schema version of the package is lower than "0.1.0". It assumes the artificial prefix does not exist if the schema version is higher than "0.1.0".

Related: #27 
