### PR TITLE
Bump schema version for some packages

### DIFF
--- a/preflight-packages/examples.jetstack.io/aks_basic/policy-manifest.yaml
+++ b/preflight-packages/examples.jetstack.io/aks_basic/policy-manifest.yaml
@@ -1,4 +1,4 @@
-schema-version: "0.1.0"
+schema-version: "0.1.1"
 id: "aks_basic"
 namespace: "examples.jetstack.io"
 package-version: "1.0.0"

--- a/preflight-packages/jetstack.io/pods/policy-manifest.yaml
+++ b/preflight-packages/jetstack.io/pods/policy-manifest.yaml
@@ -1,4 +1,4 @@
-schema-version: "0.1.0"
+schema-version: "0.1.1"
 id: "pods"
 namespace: "jetstack.io"
 package-version: "1.1.0"


### PR DESCRIPTION
Now that the `preflight_` prefix in the rego IDs has been deprecated, it is recommended that we use >= 0.1.1 for schema versions that do not use that prefix.

Related: #27 #59 

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>