### PR TITLE
Extract report generation to reports package

### DIFF
--- a/pkg/exporter/cli.go
+++ b/pkg/exporter/cli.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jetstack/preflight/pkg/packaging"
 	"github.com/jetstack/preflight/pkg/results"
+	"github.com/jetstack/preflight/pkg/rules"
 )
 
 // CLIExporter is an Exporter that outputs a report in Command Line Interface format
@@ -44,7 +45,7 @@ func (e *CLIExporter) Export(ctx context.Context, policyManifest *packaging.Poli
 		for _, rule := range section.Rules {
 			icon := color.FgYellow.Sprint("!")
 			var info interface{}
-			result := resultsByID[ruleToResult(rule.ID)]
+			result := resultsByID[rules.RuleToResult(rule.ID)]
 			if result != nil {
 				if result.IsFailureState() {
 					icon = color.FgRed.Sprint("✗")
@@ -84,7 +85,7 @@ func (e *CLIExporter) Export(ctx context.Context, policyManifest *packaging.Poli
 		fmt.Fprintf(writer, fmtError("%d rules failed: "), len(failedRules))
 		links := make([]string, len(failedRules))
 		for idx, f := range failedRules {
-			id := resultToRule(f.ID)
+			id := rules.ResultToRule(f.ID)
 			links[idx] = id
 		}
 		fmt.Fprintln(writer, strings.Join(links, ", "))

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -3,8 +3,6 @@ package exporter
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/jetstack/preflight/pkg/packaging"
 	"github.com/jetstack/preflight/pkg/results"
@@ -30,15 +28,3 @@ const (
 	// FormatIntermediate is the intermediate JSON format
 	FormatIntermediate = "intermediate"
 )
-
-func ruleToResult(ruleID string) string {
-	return strings.ReplaceAll(ruleID, ".", "_")
-}
-
-func resultToRule(resultID string) string {
-	return strings.ReplaceAll(resultID, "_", ".")
-}
-
-func legacyRuleToResult(ruleID string) string {
-	return fmt.Sprintf("preflight_%s", strings.ReplaceAll(ruleID, ".", "_"))
-}

--- a/pkg/exporter/json.go
+++ b/pkg/exporter/json.go
@@ -21,7 +21,7 @@ func NewJSONExporter() *JSONExporter {
 
 // Export writes a report with the evaluated results enriched with the metadata from the policy manifest in a JSON format.
 func (e *JSONExporter) Export(ctx context.Context, policyManifest *packaging.PolicyManifest, intermediateJSON []byte, rc *results.ResultCollection) (*bytes.Buffer, error) {
-	report, err := reports.ConstructReport(policyManifest, rc)
+	report, err := reports.NewReport(policyManifest, rc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/exporter/json.go
+++ b/pkg/exporter/json.go
@@ -5,10 +5,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/jetstack/preflight/api"
 	"github.com/jetstack/preflight/pkg/packaging"
+	"github.com/jetstack/preflight/pkg/reports"
 	"github.com/jetstack/preflight/pkg/results"
-	"github.com/jetstack/preflight/pkg/version"
 )
 
 // JSONExporter is an Exporter that outputs the results enriched with metadata in a JSON format
@@ -22,76 +21,9 @@ func NewJSONExporter() *JSONExporter {
 
 // Export writes a report with the evaluated results enriched with the metadata from the policy manifest in a JSON format.
 func (e *JSONExporter) Export(ctx context.Context, policyManifest *packaging.PolicyManifest, intermediateJSON []byte, rc *results.ResultCollection) (*bytes.Buffer, error) {
-	report := api.Report{
-		// TODO: we are omitting ID, Timestamp and Cluster for now, but it will get fixed with #1
-		PreflightVersion: version.PreflightVersion,
-		Package:          policyManifest.ID,
-		PackageInformation: api.PackageInformation{
-			Namespace: policyManifest.Namespace,
-			ID:        policyManifest.ID,
-			Version:   policyManifest.PackageVersion,
-		},
-		Name:        policyManifest.Name,
-		Description: policyManifest.Description,
-		Sections:    make([]api.ReportSection, len(policyManifest.Sections)),
-	}
-
-	for idxSection, section := range policyManifest.Sections {
-		report.Sections[idxSection] = api.ReportSection{
-			ID:          section.ID,
-			Name:        section.Name,
-			Description: section.Description,
-			Rules:       make([]api.ReportRule, len(section.Rules)),
-		}
-
-		for idxRule, rule := range section.Rules {
-			links := make([]string, len(rule.Links))
-			copy(links, rule.Links)
-
-			results := rc.ByID()
-			result := results[ruleToResult(rule.ID)]
-
-			if result == nil {
-				supportsPrefix, err := policyManifest.SupportsPreflightPrefix()
-				if err != nil {
-					return nil, err
-				}
-
-				if supportsPrefix {
-					result = results[legacyRuleToResult(rule.ID)]
-				}
-			}
-
-			var value interface{}
-			violations := []string{}
-			success := false
-			missing := false
-
-			switch {
-			case result == nil:
-				missing = true
-			case result.IsFailureState():
-				success = false
-				violations = result.Violations
-			case result.IsSuccessState():
-				success = true
-			default:
-				value = result.Value
-			}
-
-			report.Sections[idxSection].Rules[idxRule] = api.ReportRule{
-				ID:          rule.ID,
-				Name:        rule.Name,
-				Description: rule.Description,
-				Manual:      rule.Manual,
-				Remediation: rule.Remediation,
-				Links:       links,
-				Violations:  violations,
-				Success:     success,
-				Value:       value,
-				Missing:     missing,
-			}
-		}
+	report, err := reports.ConstructReport(policyManifest, rc)
+	if err != nil {
+		return nil, err
 	}
 
 	b, err := json.Marshal(report)

--- a/pkg/exporter/json_test.go
+++ b/pkg/exporter/json_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jetstack/preflight/pkg/packaging"
 	"github.com/jetstack/preflight/pkg/results"
+	"github.com/jetstack/preflight/pkg/rules"
 )
 
 func TestJSONExport(t *testing.T) {
@@ -85,8 +86,8 @@ func TestJSONExport(t *testing.T) {
 	jsonExporter := JSONExporter{}
 
 	rc := &results.ResultCollection{
-		&results.Result{ID: ruleToResult("r1"), Violations: []string{}},
-		&results.Result{ID: ruleToResult("r2"), Violations: []string{"violation"}},
+		&results.Result{ID: rules.RuleToResult("r1"), Violations: []string{}},
+		&results.Result{ID: rules.RuleToResult("r2"), Violations: []string{"violation"}},
 		&results.Result{ID: "preflight_r3", Violations: []string{"another violation"}},
 	}
 
@@ -247,8 +248,8 @@ func TestJSONExportBackwardsCompatibility(t *testing.T) {
 	jsonExporter := JSONExporter{}
 
 	rc := &results.ResultCollection{
-		&results.Result{ID: ruleToResult("r1"), Violations: []string{}},
-		&results.Result{ID: legacyRuleToResult("r2"), Violations: []string{"violation"}},
+		&results.Result{ID: rules.RuleToResult("r1"), Violations: []string{}},
+		&results.Result{ID: rules.LegacyRuleToResult("r2"), Violations: []string{"violation"}},
 	}
 
 	expectedJSON := `{

--- a/pkg/exporter/markdown.go
+++ b/pkg/exporter/markdown.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jetstack/preflight/pkg/packaging"
 	"github.com/jetstack/preflight/pkg/results"
+	"github.com/jetstack/preflight/pkg/rules"
 )
 
 // MarkdownExporter is an Exporter that outputs a report in markdown format
@@ -32,7 +33,7 @@ func (e *MarkdownExporter) Export(ctx context.Context, policyManifest *packaging
 		for _, rule := range section.Rules {
 			icon := "!"
 			var info interface{}
-			result := resultsByID[ruleToResult(rule.ID)]
+			result := resultsByID[rules.RuleToResult(rule.ID)]
 			if result != nil {
 				if result.IsFailureState() {
 					icon = "✗"
@@ -76,7 +77,7 @@ func (e *MarkdownExporter) Export(ctx context.Context, policyManifest *packaging
 		fmt.Fprintf(writer, "%d rules failed: ", len(failedRules))
 		links := make([]string, len(failedRules))
 		for idx, f := range failedRules {
-			id := resultToRule(f.ID)
+			id := rules.ResultToRule(f.ID)
 			links[idx] = fmt.Sprintf("[%s](#%s)", id, id)
 		}
 		fmt.Fprintln(writer, strings.Join(links, ", "))

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -8,8 +8,8 @@ import (
 	"github.com/jetstack/preflight/pkg/version"
 )
 
-// ConstructReport creates a report from a policy manifest and a results collection
-func ConstructReport(pm *packaging.PolicyManifest, rc *results.ResultCollection) (api.Report, error) {
+// NewReport creates a report from a policy manifest and a results collection
+func NewReport(pm *packaging.PolicyManifest, rc *results.ResultCollection) (api.Report, error) {
 	report := api.Report{
 		// TODO: we are omitting ID, Timestamp and Cluster for now, but it will get fixed with #1
 		PreflightVersion: version.PreflightVersion,

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -1,0 +1,86 @@
+package reports
+
+import (
+	"github.com/jetstack/preflight/api"
+	"github.com/jetstack/preflight/pkg/packaging"
+	"github.com/jetstack/preflight/pkg/results"
+	"github.com/jetstack/preflight/pkg/rules"
+	"github.com/jetstack/preflight/pkg/version"
+)
+
+// ConstructReport creates a report from a policy manifest and a results collection
+func ConstructReport(pm *packaging.PolicyManifest, rc *results.ResultCollection) (api.Report, error) {
+	report := api.Report{
+		// TODO: we are omitting ID, Timestamp and Cluster for now, but it will get fixed with #1
+		PreflightVersion: version.PreflightVersion,
+		Package:          pm.ID,
+		PackageInformation: api.PackageInformation{
+			Namespace: pm.Namespace,
+			ID:        pm.ID,
+			Version:   pm.PackageVersion,
+		},
+		Name:        pm.Name,
+		Description: pm.Description,
+		Sections:    make([]api.ReportSection, len(pm.Sections)),
+	}
+
+	for idxSection, section := range pm.Sections {
+		report.Sections[idxSection] = api.ReportSection{
+			ID:          section.ID,
+			Name:        section.Name,
+			Description: section.Description,
+			Rules:       make([]api.ReportRule, len(section.Rules)),
+		}
+
+		for idxRule, rule := range section.Rules {
+			links := make([]string, len(rule.Links))
+			copy(links, rule.Links)
+
+			results := rc.ByID()
+			result := results[rules.RuleToResult(rule.ID)]
+
+			if result == nil {
+				supportsPrefix, err := pm.SupportsPreflightPrefix()
+				if err != nil {
+					return api.Report{}, err
+				}
+
+				if supportsPrefix {
+					result = results[rules.LegacyRuleToResult(rule.ID)]
+				}
+			}
+
+			var value interface{}
+			violations := []string{}
+			success := false
+			missing := false
+
+			switch {
+			case result == nil:
+				missing = true
+			case result.IsFailureState():
+				success = false
+				violations = result.Violations
+			case result.IsSuccessState():
+				success = true
+			default:
+				value = result.Value
+			}
+
+			report.Sections[idxSection].Rules[idxRule] = api.ReportRule{
+				ID:          rule.ID,
+				Name:        rule.Name,
+				Description: rule.Description,
+				Manual:      rule.Manual,
+				Remediation: rule.Remediation,
+				Links:       links,
+				Violations:  violations,
+				Success:     success,
+				Value:       value,
+				Missing:     missing,
+			}
+		}
+	}
+
+	return report, nil
+}

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jetstack/preflight/pkg/version"
 )
 
-func TestConstructReport(t *testing.T) {
+func TestNewReport(t *testing.T) {
 	examplePackage := &packaging.PolicyManifest{
 		SchemaVersion:  "0.1.0",
 		ID:             "mypackage",
@@ -46,9 +46,9 @@ func TestConstructReport(t *testing.T) {
 		&results.Result{ID: rules.RuleToResult("b_rule"), Violations: []string{"violation"}},
 	}
 
-	got, err := ConstructReport(examplePackage, resultCollection)
+	got, err := NewReport(examplePackage, resultCollection)
 	if err != nil {
-		t.Fatalf("ConstructReport returned error: %v", err)
+		t.Fatalf("NewReport returned error: %v", err)
 	}
 
 	want := api.Report{

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -1,0 +1,104 @@
+package reports
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jetstack/preflight/api"
+	"github.com/jetstack/preflight/pkg/packaging"
+	"github.com/jetstack/preflight/pkg/results"
+	"github.com/jetstack/preflight/pkg/rules"
+	"github.com/jetstack/preflight/pkg/version"
+)
+
+func TestConstructReport(t *testing.T) {
+	examplePackage := &packaging.PolicyManifest{
+		SchemaVersion:  "0.1.0",
+		ID:             "mypackage",
+		Namespace:      "mynamespace",
+		Name:           "My Package",
+		RootQuery:      "data.pods",
+		PackageVersion: "1.0.0",
+		Sections: []packaging.Section{
+			{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []packaging.Rule{
+					{
+						ID:   "a_rule",
+						Name: "My Rule A",
+					},
+					{
+						ID:   "b_rule",
+						Name: "My Rule B",
+					},
+					{
+						ID:   "c_rule",
+						Name: "My Rule C (missing)",
+					},
+				},
+			},
+		},
+	}
+
+	resultCollection := &results.ResultCollection{
+		&results.Result{ID: rules.RuleToResult("a_rule"), Violations: []string{}},
+		&results.Result{ID: rules.RuleToResult("b_rule"), Violations: []string{"violation"}},
+	}
+
+	got, err := ConstructReport(examplePackage, resultCollection)
+	if err != nil {
+		t.Fatalf("ConstructReport returned error: %v", err)
+	}
+
+	want := api.Report{
+		PreflightVersion: version.PreflightVersion,
+		Package:          examplePackage.ID,
+		PackageInformation: api.PackageInformation{
+			Namespace: examplePackage.Namespace,
+			ID:        examplePackage.ID,
+			Version:   examplePackage.PackageVersion,
+		},
+		Name:        examplePackage.Name,
+		Description: examplePackage.Description,
+		Sections: []api.ReportSection{
+			api.ReportSection{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []api.ReportRule{
+					api.ReportRule{
+						ID:         "a_rule",
+						Name:       "My Rule A",
+						Manual:     false,
+						Success:    true,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{},
+					},
+					api.ReportRule{
+						ID:         "b_rule",
+						Name:       "My Rule B",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+					api.ReportRule{
+						ID:         "c_rule",
+						Name:       "My Rule C (missing)",
+						Manual:     false,
+						Success:    false,
+						Missing:    true,
+						Links:      []string{},
+						Violations: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got != want; got=%+v, want=%+v", got, want)
+	}
+}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -1,0 +1,21 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RuleToResult takes a rule identifier and returns a result identifier
+func RuleToResult(ruleID string) string {
+	return strings.ReplaceAll(ruleID, ".", "_")
+}
+
+// ResultToRule rakes a result identifier and returns a rule identifier
+func ResultToRule(resultID string) string {
+	return strings.ReplaceAll(resultID, "_", ".")
+}
+
+// LegacyRuleToResult takes a legacy rule identifier and returns a result identifier
+func LegacyRuleToResult(ruleID string) string {
+	return fmt.Sprintf("preflight_%s", strings.ReplaceAll(ruleID, ".", "_"))
+}

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -1,18 +1,16 @@
-package exporter
+package rules
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestRuleToResult(t *testing.T) {
 	rule := "something_1.2.3"
 	expectedResult := "something_1_2_3"
-	if ruleToResult(rule) != expectedResult {
+	if RuleToResult(rule) != expectedResult {
 		t.Errorf(
 			"Expected rule %q to render as result %q, but got %q",
 			rule,
 			expectedResult,
-			ruleToResult(rule),
+			RuleToResult(rule),
 		)
 	}
 }
@@ -20,12 +18,12 @@ func TestRuleToResult(t *testing.T) {
 func TestLegacyRuleToResult(t *testing.T) {
 	rule := "1.2.3"
 	expectedResult := "preflight_1_2_3"
-	if legacyRuleToResult(rule) != expectedResult {
+	if LegacyRuleToResult(rule) != expectedResult {
 		t.Errorf(
 			"Expected rule %q to render as result %q, but got %q",
 			rule,
 			expectedResult,
-			ruleToResult(rule),
+			RuleToResult(rule),
 		)
 	}
 }
@@ -33,12 +31,12 @@ func TestLegacyRuleToResult(t *testing.T) {
 func TestResultToRule(t *testing.T) {
 	result := "something_1_3_3"
 	expectedRule := "something.1.3.3"
-	if resultToRule(result) != expectedRule {
+	if ResultToRule(result) != expectedRule {
 		t.Errorf(
 			"Expected result %q to render as rule %q, but got %q",
 			result,
 			expectedRule,
-			resultToRule(result),
+			ResultToRule(result),
 		)
 	}
 }


### PR DESCRIPTION
This will allow me to generate a cluster summary and update that too
when writing output to a bucket destination.

Before this, the report generation all happened in the json exporter
which meant the report data structure wasn't available for reuse.

Done as part of https://github.com/jetstack/preflight/issues/54

Related to https://github.com/jetstack/preflight/issues/1