### PR TITLE
Report index constructors

### DIFF
--- a/api/report.go
+++ b/api/report.go
@@ -22,6 +22,29 @@ type Report struct {
 	Sections []ReportSection `json:"sections,omitempty"`
 }
 
+// Summarize produces as ReportSummary from a Report
+func (r *Report) Summarize() ReportSummary {
+	var successes, failures int
+	for _, section := range r.Sections {
+		for _, rule := range section.Rules {
+			if rule.Success {
+				successes++
+			} else {
+				failures++
+			}
+		}
+	}
+
+	return ReportSummary{
+		ID:           r.ID,
+		Package:      r.Package,
+		Cluster:      r.Cluster,
+		Timestamp:    r.Timestamp,
+		FailureCount: failures,
+		SuccessCount: successes,
+	}
+}
+
 // PackageInformation contains all the details to identify a package.
 type PackageInformation struct {
 	// Namespace the package belongs to.

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -10,6 +10,24 @@ import (
 	"github.com/jetstack/preflight/pkg/version"
 )
 
+// ConstructClusterSummary builds a summary for a current cluster based on a
+// freshly generated report set
+func ConstructClusterSummary(reports []api.Report) (api.ClusterSummary, error) {
+	if len(reports) < 1 {
+		return api.ClusterSummary{}, fmt.Errorf("you must supply at least one report")
+	}
+
+	reportSet, err := ConstructReportSet(reports)
+	if err != nil {
+		return api.ClusterSummary{}, fmt.Errorf("error constructing report set: %v", err)
+	}
+
+	return api.ClusterSummary{
+		Cluster:         reportSet.Cluster,
+		LatestReportSet: &reportSet,
+	}, nil
+}
+
 // ConstructReportSet generates a summarized report set from the supplied reports
 func ConstructReportSet(reports []api.Report) (api.ReportSet, error) {
 	if len(reports) < 1 {

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -1,12 +1,39 @@
 package reports
 
 import (
+	"fmt"
+
 	"github.com/jetstack/preflight/api"
 	"github.com/jetstack/preflight/pkg/packaging"
 	"github.com/jetstack/preflight/pkg/results"
 	"github.com/jetstack/preflight/pkg/rules"
 	"github.com/jetstack/preflight/pkg/version"
 )
+
+// ConstructReportSet generates a summarized report set from the supplied reports
+func ConstructReportSet(reports []api.Report) (api.ReportSet, error) {
+	if len(reports) < 1 {
+		return api.ReportSet{}, fmt.Errorf("you must supply at least one report")
+	}
+
+	reportSet := api.ReportSet{
+		Cluster:   reports[0].Cluster,
+		Timestamp: reports[0].Timestamp,
+		Reports:   []*api.ReportSummary{},
+	}
+
+	for _, report := range reports {
+		summary := SummarizeReport(report)
+		reportSet.Reports = append(reportSet.Reports, &summary)
+	}
+
+	for _, summary := range reportSet.Reports {
+		reportSet.SuccessCount += summary.SuccessCount
+		reportSet.FailureCount += summary.FailureCount
+	}
+
+	return reportSet, nil
+}
 
 // SummarizeReport produces as ReportSummary from a Report
 func SummarizeReport(report api.Report) api.ReportSummary {

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -10,14 +10,14 @@ import (
 	"github.com/jetstack/preflight/pkg/version"
 )
 
-// ConstructClusterSummary builds a summary for a current cluster based on a
+// NewClusterSummary builds a summary for a current cluster based on a
 // freshly generated report set
-func ConstructClusterSummary(reports []api.Report) (api.ClusterSummary, error) {
+func NewClusterSummary(reports []api.Report) (api.ClusterSummary, error) {
 	if len(reports) < 1 {
 		return api.ClusterSummary{}, fmt.Errorf("you must supply at least one report")
 	}
 
-	reportSet, err := ConstructReportSet(reports)
+	reportSet, err := NewReportSet(reports)
 	if err != nil {
 		return api.ClusterSummary{}, fmt.Errorf("error constructing report set: %v", err)
 	}
@@ -28,8 +28,8 @@ func ConstructClusterSummary(reports []api.Report) (api.ClusterSummary, error) {
 	}, nil
 }
 
-// ConstructReportSet generates a summarized report set from the supplied reports
-func ConstructReportSet(reports []api.Report) (api.ReportSet, error) {
+// NewReportSet generates a summarized report set from the supplied reports
+func NewReportSet(reports []api.Report) (api.ReportSet, error) {
 	if len(reports) < 1 {
 		return api.ReportSet{}, fmt.Errorf("you must supply at least one report")
 	}

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -28,10 +28,26 @@ func NewClusterSummary(reports []api.Report) (api.ClusterSummary, error) {
 	}, nil
 }
 
-// NewReportSet generates a summarized report set from the supplied reports
+// NewReportSet generates a summarized ReportSet from the supplied reports
+// all reports should have the same Cluster and Timestamp
 func NewReportSet(reports []api.Report) (api.ReportSet, error) {
 	if len(reports) < 1 {
 		return api.ReportSet{}, fmt.Errorf("you must supply at least one report")
+	}
+
+	clusters := map[string]int{}
+	timestamps := map[api.Time]int{}
+	for _, r := range reports {
+		clusters[r.Cluster]++
+		timestamps[r.Timestamp]++
+	}
+
+	if len(clusters) > 1 {
+		return api.ReportSet{}, fmt.Errorf("reports must be for the same cluster")
+	}
+
+	if len(timestamps) > 1 {
+		return api.ReportSet{}, fmt.Errorf("reports must have the same timestamp")
 	}
 
 	reportSet := api.ReportSet{

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -57,11 +57,16 @@ func NewReportSet(reports []api.Report) (api.ReportSet, error) {
 	}
 
 	for _, report := range reports {
+		if report.Cluster != reportSet.Cluster {
+			return reportSet, fmt.Errorf("reports must be for the same cluster")
+		}
+		if report.Timestamp != reportSet.Timestamp {
+			return reportSet, fmt.Errorf("reports must be for the same timestamp")
+		}
+
 		summary := report.Summarize()
 		reportSet.Reports = append(reportSet.Reports, &summary)
-	}
 
-	for _, summary := range reportSet.Reports {
 		reportSet.SuccessCount += summary.SuccessCount
 		reportSet.FailureCount += summary.FailureCount
 	}

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -57,7 +57,7 @@ func NewReportSet(reports []api.Report) (api.ReportSet, error) {
 	}
 
 	for _, report := range reports {
-		summary := SummarizeReport(report)
+		summary := report.Summarize()
 		reportSet.Reports = append(reportSet.Reports, &summary)
 	}
 
@@ -67,29 +67,6 @@ func NewReportSet(reports []api.Report) (api.ReportSet, error) {
 	}
 
 	return reportSet, nil
-}
-
-// SummarizeReport produces as ReportSummary from a Report
-func SummarizeReport(report api.Report) api.ReportSummary {
-	var successes, failures int
-	for _, section := range report.Sections {
-		for _, rule := range section.Rules {
-			if rule.Success {
-				successes++
-			} else {
-				failures++
-			}
-		}
-	}
-
-	return api.ReportSummary{
-		ID:           report.ID,
-		Package:      report.Package,
-		Cluster:      report.Cluster,
-		Timestamp:    report.Timestamp,
-		FailureCount: failures,
-		SuccessCount: successes,
-	}
 }
 
 // NewReport creates a report from a policy manifest and a results collection

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NewClusterSummary builds a summary for a current cluster based on a
-// freshly generated report set
+// freshly generated slice of reports.
 func NewClusterSummary(reports []api.Report) (api.ClusterSummary, error) {
 	if len(reports) < 1 {
 		return api.ClusterSummary{}, fmt.Errorf("you must supply at least one report")

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -8,6 +8,29 @@ import (
 	"github.com/jetstack/preflight/pkg/version"
 )
 
+// SummarizeReport produces as ReportSummary from a Report
+func SummarizeReport(report api.Report) api.ReportSummary {
+	var successes, failures int
+	for _, section := range report.Sections {
+		for _, rule := range section.Rules {
+			if rule.Success {
+				successes++
+			} else {
+				failures++
+			}
+		}
+	}
+
+	return api.ReportSummary{
+		ID:           report.ID,
+		Package:      report.Package,
+		Cluster:      report.Cluster,
+		Timestamp:    report.Timestamp,
+		FailureCount: failures,
+		SuccessCount: successes,
+	}
+}
+
 // NewReport creates a report from a policy manifest and a results collection
 func NewReport(pm *packaging.PolicyManifest, rc *results.ResultCollection) (api.Report, error) {
 	report := api.Report{

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -11,6 +11,134 @@ import (
 	"github.com/jetstack/preflight/pkg/version"
 )
 
+func TestConstructClusterSummary(t *testing.T) {
+	exampleReport1 := api.Report{
+		ID:               "exampleReport1",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Name:        "examplePackage.Name",
+		Description: "examplePackage.Description",
+		Cluster:     "exampleCluster",
+		Sections: []api.ReportSection{
+			api.ReportSection{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []api.ReportRule{
+					api.ReportRule{
+						ID:         "a_rule",
+						Name:       "My Rule A",
+						Manual:     false,
+						Success:    true,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{},
+					},
+					api.ReportRule{
+						ID:         "b_rule",
+						Name:       "My Rule B",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+					api.ReportRule{
+						ID:         "c_rule",
+						Name:       "My Rule C (missing)",
+						Manual:     false,
+						Success:    false,
+						Missing:    true,
+						Links:      []string{},
+						Violations: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	exampleReport2 := api.Report{
+		ID:               "exampleReport2",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Name:        "examplePackage.Name",
+		Description: "examplePackage.Description",
+		Cluster:     "exampleCluster",
+		Sections: []api.ReportSection{
+			api.ReportSection{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []api.ReportRule{
+					api.ReportRule{
+						ID:         "a_rule",
+						Name:       "My Rule A",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+					api.ReportRule{
+						ID:         "b_rule",
+						Name:       "My Rule B",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := ConstructClusterSummary([]api.Report{exampleReport1, exampleReport2})
+	if err != nil {
+		t.Fatalf("ConstructClusterSummary raised an error %v", err)
+	}
+
+	want := api.ClusterSummary{
+		Cluster: "exampleCluster",
+		LatestReportSet: &api.ReportSet{
+			Cluster:      "exampleCluster",
+			Timestamp:    api.Time{},
+			FailureCount: 4,
+			SuccessCount: 1,
+			Reports: []*api.ReportSummary{
+				&api.ReportSummary{
+					ID:           "exampleReport1",
+					Package:      "examplePackage.ID",
+					Cluster:      "exampleCluster",
+					Timestamp:    api.Time{},
+					FailureCount: 2, // missing is a failure
+					SuccessCount: 1,
+				},
+				&api.ReportSummary{
+					ID:           "exampleReport2",
+					Package:      "examplePackage.ID",
+					Cluster:      "exampleCluster",
+					Timestamp:    api.Time{},
+					FailureCount: 2,
+					SuccessCount: 0,
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got != want;\ngot= %+v,\nwant=%+v", got, want)
+	}
+}
+
 func TestConstructReportSet(t *testing.T) {
 	exampleReport1 := api.Report{
 		ID:               "exampleReport1",

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -11,7 +11,132 @@ import (
 	"github.com/jetstack/preflight/pkg/version"
 )
 
-func TestGenerateSummary(t *testing.T) {
+func TestConstructReportSet(t *testing.T) {
+	exampleReport1 := api.Report{
+		ID:               "exampleReport1",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Name:        "examplePackage.Name",
+		Description: "examplePackage.Description",
+		Cluster:     "exampleCluster",
+		Sections: []api.ReportSection{
+			api.ReportSection{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []api.ReportRule{
+					api.ReportRule{
+						ID:         "a_rule",
+						Name:       "My Rule A",
+						Manual:     false,
+						Success:    true,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{},
+					},
+					api.ReportRule{
+						ID:         "b_rule",
+						Name:       "My Rule B",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+					api.ReportRule{
+						ID:         "c_rule",
+						Name:       "My Rule C (missing)",
+						Manual:     false,
+						Success:    false,
+						Missing:    true,
+						Links:      []string{},
+						Violations: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	exampleReport2 := api.Report{
+		ID:               "exampleReport2",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Name:        "examplePackage.Name",
+		Description: "examplePackage.Description",
+		Cluster:     "exampleCluster",
+		Sections: []api.ReportSection{
+			api.ReportSection{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []api.ReportRule{
+					api.ReportRule{
+						ID:         "a_rule",
+						Name:       "My Rule A",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+					api.ReportRule{
+						ID:         "b_rule",
+						Name:       "My Rule B",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := ConstructReportSet([]api.Report{exampleReport1, exampleReport2})
+	if err != nil {
+		t.Fatalf("ConstructReportSet raised an error %v", err)
+	}
+
+	want := api.ReportSet{
+		Cluster:      "exampleCluster",
+		Timestamp:    api.Time{},
+		FailureCount: 4,
+		SuccessCount: 1,
+		Reports: []*api.ReportSummary{
+			&api.ReportSummary{
+				ID:           "exampleReport1",
+				Package:      "examplePackage.ID",
+				Cluster:      "exampleCluster",
+				Timestamp:    api.Time{},
+				FailureCount: 2, // missing is a failure
+				SuccessCount: 1,
+			},
+			&api.ReportSummary{
+				ID:           "exampleReport2",
+				Package:      "examplePackage.ID",
+				Cluster:      "exampleCluster",
+				Timestamp:    api.Time{},
+				FailureCount: 2,
+				SuccessCount: 0,
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got != want;\ngot= %+v,\nwant=%+v", got, want)
+	}
+}
+
+func TestSummarizeReport(t *testing.T) {
 	exampleReport := api.Report{
 		ID:               "exampleReport",
 		PreflightVersion: "version.PreflightVersion",

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -13,97 +13,97 @@ import (
 	"github.com/jetstack/preflight/pkg/version"
 )
 
+var fixtureReport1 = api.Report{
+	ID:               "fixtureReport1",
+	PreflightVersion: "version.PreflightVersion",
+	Package:          "examplePackage.ID",
+	PackageInformation: api.PackageInformation{
+		Namespace: "examplePackage.Namespace",
+		ID:        "examplePackage.ID",
+		Version:   "examplePackage.PackageVersion",
+	},
+	Name:        "examplePackage.Name",
+	Description: "examplePackage.Description",
+	Cluster:     "exampleCluster",
+	Sections: []api.ReportSection{
+		api.ReportSection{
+			ID:   "a_section",
+			Name: "My section",
+			Rules: []api.ReportRule{
+				api.ReportRule{
+					ID:         "a_rule",
+					Name:       "My Rule A",
+					Manual:     false,
+					Success:    true,
+					Missing:    false,
+					Links:      []string{},
+					Violations: []string{},
+				},
+				api.ReportRule{
+					ID:         "b_rule",
+					Name:       "My Rule B",
+					Manual:     false,
+					Success:    false,
+					Missing:    false,
+					Links:      []string{},
+					Violations: []string{"violation"},
+				},
+				api.ReportRule{
+					ID:         "c_rule",
+					Name:       "My Rule C (missing)",
+					Manual:     false,
+					Success:    false,
+					Missing:    true,
+					Links:      []string{},
+					Violations: []string{},
+				},
+			},
+		},
+	},
+}
+
+var fixtureReport2 = api.Report{
+	ID:               "fixtureReport2",
+	PreflightVersion: "version.PreflightVersion",
+	Package:          "examplePackage.ID",
+	PackageInformation: api.PackageInformation{
+		Namespace: "examplePackage.Namespace",
+		ID:        "examplePackage.ID",
+		Version:   "examplePackage.PackageVersion",
+	},
+	Name:        "examplePackage.Name",
+	Description: "examplePackage.Description",
+	Cluster:     "exampleCluster",
+	Sections: []api.ReportSection{
+		api.ReportSection{
+			ID:   "a_section",
+			Name: "My section",
+			Rules: []api.ReportRule{
+				api.ReportRule{
+					ID:         "a_rule",
+					Name:       "My Rule A",
+					Manual:     false,
+					Success:    false,
+					Missing:    false,
+					Links:      []string{},
+					Violations: []string{"violation"},
+				},
+				api.ReportRule{
+					ID:         "b_rule",
+					Name:       "My Rule B",
+					Manual:     false,
+					Success:    false,
+					Missing:    false,
+					Links:      []string{},
+					Violations: []string{"violation"},
+				},
+			},
+		},
+	},
+}
+
 func TestNewClusterSummary(t *testing.T) {
-	exampleReport1 := api.Report{
-		ID:               "exampleReport1",
-		PreflightVersion: "version.PreflightVersion",
-		Package:          "examplePackage.ID",
-		PackageInformation: api.PackageInformation{
-			Namespace: "examplePackage.Namespace",
-			ID:        "examplePackage.ID",
-			Version:   "examplePackage.PackageVersion",
-		},
-		Name:        "examplePackage.Name",
-		Description: "examplePackage.Description",
-		Cluster:     "exampleCluster",
-		Sections: []api.ReportSection{
-			api.ReportSection{
-				ID:   "a_section",
-				Name: "My section",
-				Rules: []api.ReportRule{
-					api.ReportRule{
-						ID:         "a_rule",
-						Name:       "My Rule A",
-						Manual:     false,
-						Success:    true,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{},
-					},
-					api.ReportRule{
-						ID:         "b_rule",
-						Name:       "My Rule B",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-					api.ReportRule{
-						ID:         "c_rule",
-						Name:       "My Rule C (missing)",
-						Manual:     false,
-						Success:    false,
-						Missing:    true,
-						Links:      []string{},
-						Violations: []string{},
-					},
-				},
-			},
-		},
-	}
-
-	exampleReport2 := api.Report{
-		ID:               "exampleReport2",
-		PreflightVersion: "version.PreflightVersion",
-		Package:          "examplePackage.ID",
-		PackageInformation: api.PackageInformation{
-			Namespace: "examplePackage.Namespace",
-			ID:        "examplePackage.ID",
-			Version:   "examplePackage.PackageVersion",
-		},
-		Name:        "examplePackage.Name",
-		Description: "examplePackage.Description",
-		Cluster:     "exampleCluster",
-		Sections: []api.ReportSection{
-			api.ReportSection{
-				ID:   "a_section",
-				Name: "My section",
-				Rules: []api.ReportRule{
-					api.ReportRule{
-						ID:         "a_rule",
-						Name:       "My Rule A",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-					api.ReportRule{
-						ID:         "b_rule",
-						Name:       "My Rule B",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-				},
-			},
-		},
-	}
-
-	got, err := NewClusterSummary([]api.Report{exampleReport1, exampleReport2})
+	got, err := NewClusterSummary([]api.Report{fixtureReport1, fixtureReport2})
 	if err != nil {
 		t.Fatalf("NewClusterSummary raised an error %v", err)
 	}
@@ -117,7 +117,7 @@ func TestNewClusterSummary(t *testing.T) {
 			SuccessCount: 1,
 			Reports: []*api.ReportSummary{
 				&api.ReportSummary{
-					ID:           "exampleReport1",
+					ID:           "fixtureReport1",
 					Package:      "examplePackage.ID",
 					Cluster:      "exampleCluster",
 					Timestamp:    api.Time{},
@@ -125,7 +125,7 @@ func TestNewClusterSummary(t *testing.T) {
 					SuccessCount: 1,
 				},
 				&api.ReportSummary{
-					ID:           "exampleReport2",
+					ID:           "fixtureReport2",
 					Package:      "examplePackage.ID",
 					Cluster:      "exampleCluster",
 					Timestamp:    api.Time{},
@@ -142,96 +142,7 @@ func TestNewClusterSummary(t *testing.T) {
 }
 
 func TestNewReportSet(t *testing.T) {
-	exampleReport1 := api.Report{
-		ID:               "exampleReport1",
-		PreflightVersion: "version.PreflightVersion",
-		Package:          "examplePackage.ID",
-		PackageInformation: api.PackageInformation{
-			Namespace: "examplePackage.Namespace",
-			ID:        "examplePackage.ID",
-			Version:   "examplePackage.PackageVersion",
-		},
-		Name:        "examplePackage.Name",
-		Description: "examplePackage.Description",
-		Cluster:     "exampleCluster",
-		Sections: []api.ReportSection{
-			api.ReportSection{
-				ID:   "a_section",
-				Name: "My section",
-				Rules: []api.ReportRule{
-					api.ReportRule{
-						ID:         "a_rule",
-						Name:       "My Rule A",
-						Manual:     false,
-						Success:    true,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{},
-					},
-					api.ReportRule{
-						ID:         "b_rule",
-						Name:       "My Rule B",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-					api.ReportRule{
-						ID:         "c_rule",
-						Name:       "My Rule C (missing)",
-						Manual:     false,
-						Success:    false,
-						Missing:    true,
-						Links:      []string{},
-						Violations: []string{},
-					},
-				},
-			},
-		},
-	}
-
-	exampleReport2 := api.Report{
-		ID:               "exampleReport2",
-		PreflightVersion: "version.PreflightVersion",
-		Package:          "examplePackage.ID",
-		PackageInformation: api.PackageInformation{
-			Namespace: "examplePackage.Namespace",
-			ID:        "examplePackage.ID",
-			Version:   "examplePackage.PackageVersion",
-		},
-		Name:        "examplePackage.Name",
-		Description: "examplePackage.Description",
-		Cluster:     "exampleCluster",
-		Sections: []api.ReportSection{
-			api.ReportSection{
-				ID:   "a_section",
-				Name: "My section",
-				Rules: []api.ReportRule{
-					api.ReportRule{
-						ID:         "a_rule",
-						Name:       "My Rule A",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-					api.ReportRule{
-						ID:         "b_rule",
-						Name:       "My Rule B",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-				},
-			},
-		},
-	}
-
-	got, err := NewReportSet([]api.Report{exampleReport1, exampleReport2})
+	got, err := NewReportSet([]api.Report{fixtureReport1, fixtureReport2})
 	if err != nil {
 		t.Fatalf("NewReportSet raised an error %v", err)
 	}
@@ -243,7 +154,7 @@ func TestNewReportSet(t *testing.T) {
 		SuccessCount: 1,
 		Reports: []*api.ReportSummary{
 			&api.ReportSummary{
-				ID:           "exampleReport1",
+				ID:           "fixtureReport1",
 				Package:      "examplePackage.ID",
 				Cluster:      "exampleCluster",
 				Timestamp:    api.Time{},
@@ -251,7 +162,7 @@ func TestNewReportSet(t *testing.T) {
 				SuccessCount: 1,
 			},
 			&api.ReportSummary{
-				ID:           "exampleReport2",
+				ID:           "fixtureReport2",
 				Package:      "examplePackage.ID",
 				Cluster:      "exampleCluster",
 				Timestamp:    api.Time{},
@@ -267,96 +178,12 @@ func TestNewReportSet(t *testing.T) {
 }
 
 func TestNewReportSetDifferentClusters(t *testing.T) {
-	exampleReport1 := api.Report{
-		ID:               "exampleReport1",
-		PreflightVersion: "version.PreflightVersion",
-		Package:          "examplePackage.ID",
-		PackageInformation: api.PackageInformation{
-			Namespace: "examplePackage.Namespace",
-			ID:        "examplePackage.ID",
-			Version:   "examplePackage.PackageVersion",
-		},
-		Name:        "examplePackage.Name",
-		Description: "examplePackage.Description",
-		Cluster:     "exampleCluster1",
-		Sections: []api.ReportSection{
-			api.ReportSection{
-				ID:   "a_section",
-				Name: "My section",
-				Rules: []api.ReportRule{
-					api.ReportRule{
-						ID:         "a_rule",
-						Name:       "My Rule A",
-						Manual:     false,
-						Success:    true,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{},
-					},
-					api.ReportRule{
-						ID:         "b_rule",
-						Name:       "My Rule B",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-					api.ReportRule{
-						ID:         "c_rule",
-						Name:       "My Rule C (missing)",
-						Manual:     false,
-						Success:    false,
-						Missing:    true,
-						Links:      []string{},
-						Violations: []string{},
-					},
-				},
-			},
-		},
-	}
+	exampleReportCluster1 := fixtureReport1
+	exampleReportCluster1.Cluster = "exampleCluster1"
+	exampleReportCluster2 := fixtureReport2
+	exampleReportCluster2.Cluster = "exampleCluster2"
 
-	exampleReport2 := api.Report{
-		ID:               "exampleReport2",
-		PreflightVersion: "version.PreflightVersion",
-		Package:          "examplePackage.ID",
-		PackageInformation: api.PackageInformation{
-			Namespace: "examplePackage.Namespace",
-			ID:        "examplePackage.ID",
-			Version:   "examplePackage.PackageVersion",
-		},
-		Name:        "examplePackage.Name",
-		Description: "examplePackage.Description",
-		Cluster:     "exampleCluster2",
-		Sections: []api.ReportSection{
-			api.ReportSection{
-				ID:   "a_section",
-				Name: "My section",
-				Rules: []api.ReportRule{
-					api.ReportRule{
-						ID:         "a_rule",
-						Name:       "My Rule A",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-					api.ReportRule{
-						ID:         "b_rule",
-						Name:       "My Rule B",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-				},
-			},
-		},
-	}
-
-	_, got := NewReportSet([]api.Report{exampleReport1, exampleReport2})
+	_, got := NewReportSet([]api.Report{exampleReportCluster1, exampleReportCluster2})
 	want := fmt.Errorf("reports must be for the same cluster")
 
 	if got.Error() != want.Error() {
@@ -365,97 +192,11 @@ func TestNewReportSetDifferentClusters(t *testing.T) {
 }
 
 func TestNewReportSetDifferentTimestamps(t *testing.T) {
-	exampleReport1 := api.Report{
-		ID:               "exampleReport1",
-		PreflightVersion: "version.PreflightVersion",
-		Package:          "examplePackage.ID",
-		PackageInformation: api.PackageInformation{
-			Namespace: "examplePackage.Namespace",
-			ID:        "examplePackage.ID",
-			Version:   "examplePackage.PackageVersion",
-		},
-		Name:        "examplePackage.Name",
-		Description: "examplePackage.Description",
-		Cluster:     "exampleCluster",
-		Sections: []api.ReportSection{
-			api.ReportSection{
-				ID:   "a_section",
-				Name: "My section",
-				Rules: []api.ReportRule{
-					api.ReportRule{
-						ID:         "a_rule",
-						Name:       "My Rule A",
-						Manual:     false,
-						Success:    true,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{},
-					},
-					api.ReportRule{
-						ID:         "b_rule",
-						Name:       "My Rule B",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-					api.ReportRule{
-						ID:         "c_rule",
-						Name:       "My Rule C (missing)",
-						Manual:     false,
-						Success:    false,
-						Missing:    true,
-						Links:      []string{},
-						Violations: []string{},
-					},
-				},
-			},
-		},
-	}
+	exampleReportTimestamp1 := fixtureReport1
+	exampleReportTimestamp2 := fixtureReport2
+	exampleReportTimestamp2.Timestamp = api.Time{Time: time.Now()}
 
-	exampleReport2 := api.Report{
-		ID:               "exampleReport2",
-		PreflightVersion: "version.PreflightVersion",
-		Package:          "examplePackage.ID",
-		PackageInformation: api.PackageInformation{
-			Namespace: "examplePackage.Namespace",
-			ID:        "examplePackage.ID",
-			Version:   "examplePackage.PackageVersion",
-		},
-		Name:        "examplePackage.Name",
-		Description: "examplePackage.Description",
-		Cluster:     "exampleCluster",
-		Timestamp:   api.Time{Time: time.Now()},
-		Sections: []api.ReportSection{
-			api.ReportSection{
-				ID:   "a_section",
-				Name: "My section",
-				Rules: []api.ReportRule{
-					api.ReportRule{
-						ID:         "a_rule",
-						Name:       "My Rule A",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-					api.ReportRule{
-						ID:         "b_rule",
-						Name:       "My Rule B",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-				},
-			},
-		},
-	}
-
-	_, got := NewReportSet([]api.Report{exampleReport1, exampleReport2})
+	_, got := NewReportSet([]api.Report{exampleReportTimestamp1, exampleReportTimestamp2})
 	want := fmt.Errorf("reports must have the same timestamp")
 
 	if got.Error() != want.Error() {
@@ -464,54 +205,8 @@ func TestNewReportSetDifferentTimestamps(t *testing.T) {
 }
 
 func TestReportSummarize(t *testing.T) {
-	exampleReport := api.Report{
-		ID:               "exampleReport",
-		PreflightVersion: "version.PreflightVersion",
-		Package:          "examplePackage.ID",
-		PackageInformation: api.PackageInformation{
-			Namespace: "examplePackage.Namespace",
-			ID:        "examplePackage.ID",
-			Version:   "examplePackage.PackageVersion",
-		},
-		Name:        "examplePackage.Name",
-		Description: "examplePackage.Description",
-		Cluster:     "exampleCluster",
-		Sections: []api.ReportSection{
-			api.ReportSection{
-				ID:   "a_section",
-				Name: "My section",
-				Rules: []api.ReportRule{
-					api.ReportRule{
-						ID:         "a_rule",
-						Name:       "My Rule A",
-						Manual:     false,
-						Success:    true,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{},
-					},
-					api.ReportRule{
-						ID:         "b_rule",
-						Name:       "My Rule B",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-					api.ReportRule{
-						ID:         "c_rule",
-						Name:       "My Rule C (missing)",
-						Manual:     false,
-						Success:    false,
-						Missing:    true,
-						Links:      []string{},
-						Violations: []string{},
-					},
-				},
-			},
-		},
-	}
+	exampleReport := fixtureReport1
+	exampleReport.ID = "exampleReport"
 
 	got := exampleReport.Summarize()
 

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jetstack/preflight/pkg/version"
 )
 
-func TestConstructClusterSummary(t *testing.T) {
+func TestNewClusterSummary(t *testing.T) {
 	exampleReport1 := api.Report{
 		ID:               "exampleReport1",
 		PreflightVersion: "version.PreflightVersion",
@@ -101,9 +101,9 @@ func TestConstructClusterSummary(t *testing.T) {
 		},
 	}
 
-	got, err := ConstructClusterSummary([]api.Report{exampleReport1, exampleReport2})
+	got, err := NewClusterSummary([]api.Report{exampleReport1, exampleReport2})
 	if err != nil {
-		t.Fatalf("ConstructClusterSummary raised an error %v", err)
+		t.Fatalf("NewClusterSummary raised an error %v", err)
 	}
 
 	want := api.ClusterSummary{
@@ -139,7 +139,7 @@ func TestConstructClusterSummary(t *testing.T) {
 	}
 }
 
-func TestConstructReportSet(t *testing.T) {
+func TestNewReportSet(t *testing.T) {
 	exampleReport1 := api.Report{
 		ID:               "exampleReport1",
 		PreflightVersion: "version.PreflightVersion",
@@ -229,9 +229,9 @@ func TestConstructReportSet(t *testing.T) {
 		},
 	}
 
-	got, err := ConstructReportSet([]api.Report{exampleReport1, exampleReport2})
+	got, err := NewReportSet([]api.Report{exampleReport1, exampleReport2})
 	if err != nil {
-		t.Fatalf("ConstructReportSet raised an error %v", err)
+		t.Fatalf("NewReportSet raised an error %v", err)
 	}
 
 	want := api.ReportSet{

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -11,6 +11,72 @@ import (
 	"github.com/jetstack/preflight/pkg/version"
 )
 
+func TestGenerateSummary(t *testing.T) {
+	exampleReport := api.Report{
+		ID:               "exampleReport",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Name:        "examplePackage.Name",
+		Description: "examplePackage.Description",
+		Cluster:     "exampleCluster",
+		Sections: []api.ReportSection{
+			api.ReportSection{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []api.ReportRule{
+					api.ReportRule{
+						ID:         "a_rule",
+						Name:       "My Rule A",
+						Manual:     false,
+						Success:    true,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{},
+					},
+					api.ReportRule{
+						ID:         "b_rule",
+						Name:       "My Rule B",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+					api.ReportRule{
+						ID:         "c_rule",
+						Name:       "My Rule C (missing)",
+						Manual:     false,
+						Success:    false,
+						Missing:    true,
+						Links:      []string{},
+						Violations: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	got := SummarizeReport(exampleReport)
+
+	want := api.ReportSummary{
+		ID:           "exampleReport",
+		Package:      "examplePackage.ID",
+		Cluster:      "exampleCluster",
+		Timestamp:    api.Time{},
+		FailureCount: 2, // missing is a failure
+		SuccessCount: 1,
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got != want;\ngot= %+v,\nwant=%+v", got, want)
+	}
+}
+
 func TestNewReport(t *testing.T) {
 	examplePackage := &packaging.PolicyManifest{
 		SchemaVersion:  "0.1.0",

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -463,7 +463,7 @@ func TestNewReportSetDifferentTimestamps(t *testing.T) {
 	}
 }
 
-func TestSummarizeReport(t *testing.T) {
+func TestReportSummarize(t *testing.T) {
 	exampleReport := api.Report{
 		ID:               "exampleReport",
 		PreflightVersion: "version.PreflightVersion",
@@ -513,7 +513,7 @@ func TestSummarizeReport(t *testing.T) {
 		},
 	}
 
-	got := SummarizeReport(exampleReport)
+	got := exampleReport.Summarize()
 
 	want := api.ReportSummary{
 		ID:           "exampleReport",

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -1,8 +1,10 @@
 package reports
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/jetstack/preflight/api"
 	"github.com/jetstack/preflight/pkg/packaging"
@@ -261,6 +263,203 @@ func TestNewReportSet(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got != want;\ngot= %+v,\nwant=%+v", got, want)
+	}
+}
+
+func TestNewReportSetDifferentClusters(t *testing.T) {
+	exampleReport1 := api.Report{
+		ID:               "exampleReport1",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Name:        "examplePackage.Name",
+		Description: "examplePackage.Description",
+		Cluster:     "exampleCluster1",
+		Sections: []api.ReportSection{
+			api.ReportSection{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []api.ReportRule{
+					api.ReportRule{
+						ID:         "a_rule",
+						Name:       "My Rule A",
+						Manual:     false,
+						Success:    true,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{},
+					},
+					api.ReportRule{
+						ID:         "b_rule",
+						Name:       "My Rule B",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+					api.ReportRule{
+						ID:         "c_rule",
+						Name:       "My Rule C (missing)",
+						Manual:     false,
+						Success:    false,
+						Missing:    true,
+						Links:      []string{},
+						Violations: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	exampleReport2 := api.Report{
+		ID:               "exampleReport2",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Name:        "examplePackage.Name",
+		Description: "examplePackage.Description",
+		Cluster:     "exampleCluster2",
+		Sections: []api.ReportSection{
+			api.ReportSection{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []api.ReportRule{
+					api.ReportRule{
+						ID:         "a_rule",
+						Name:       "My Rule A",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+					api.ReportRule{
+						ID:         "b_rule",
+						Name:       "My Rule B",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+				},
+			},
+		},
+	}
+
+	_, got := NewReportSet([]api.Report{exampleReport1, exampleReport2})
+	want := fmt.Errorf("reports must be for the same cluster")
+
+	if got.Error() != want.Error() {
+		t.Fatalf("got != want;\ngot= %s,\nwant=%s", got, want)
+	}
+}
+
+func TestNewReportSetDifferentTimestamps(t *testing.T) {
+	exampleReport1 := api.Report{
+		ID:               "exampleReport1",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Name:        "examplePackage.Name",
+		Description: "examplePackage.Description",
+		Cluster:     "exampleCluster",
+		Sections: []api.ReportSection{
+			api.ReportSection{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []api.ReportRule{
+					api.ReportRule{
+						ID:         "a_rule",
+						Name:       "My Rule A",
+						Manual:     false,
+						Success:    true,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{},
+					},
+					api.ReportRule{
+						ID:         "b_rule",
+						Name:       "My Rule B",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+					api.ReportRule{
+						ID:         "c_rule",
+						Name:       "My Rule C (missing)",
+						Manual:     false,
+						Success:    false,
+						Missing:    true,
+						Links:      []string{},
+						Violations: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	exampleReport2 := api.Report{
+		ID:               "exampleReport2",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Name:        "examplePackage.Name",
+		Description: "examplePackage.Description",
+		Cluster:     "exampleCluster",
+		Timestamp:   api.Time{Time: time.Now()},
+		Sections: []api.ReportSection{
+			api.ReportSection{
+				ID:   "a_section",
+				Name: "My section",
+				Rules: []api.ReportRule{
+					api.ReportRule{
+						ID:         "a_rule",
+						Name:       "My Rule A",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+					api.ReportRule{
+						ID:         "b_rule",
+						Name:       "My Rule B",
+						Manual:     false,
+						Success:    false,
+						Missing:    false,
+						Links:      []string{},
+						Violations: []string{"violation"},
+					},
+				},
+			},
+		},
+	}
+
+	_, got := NewReportSet([]api.Report{exampleReport1, exampleReport2})
+	want := fmt.Errorf("reports must have the same timestamp")
+
+	if got.Error() != want.Error() {
+		t.Fatalf("got != want;\ngot= %s,\nwant=%s", got, want)
 	}
 }
 


### PR DESCRIPTION
Being done as part of #54

Few things I'm not sure about here:
- if a single test for generating a clustersummary would be enough - there is a lot of duplication
- if some functions such as summarize report should be registered on the report struct.