### PR TITLE
Make command to fail if missing Rego definition

### DIFF
--- a/pkg/exporter/json.go
+++ b/pkg/exporter/json.go
@@ -23,15 +23,18 @@ func NewJSONExporter() *JSONExporter {
 func (e *JSONExporter) Export(ctx context.Context, policyManifest *packaging.PolicyManifest, intermediateJSON []byte, rc *results.ResultCollection) (*bytes.Buffer, error) {
 	report, err := reports.NewReport(policyManifest, rc)
 	if err != nil {
-		return nil, err
+		if _, ok := err.(*reports.MissingRegoDefinitionError); !ok {
+			return nil, err
+		}
 	}
+	missingRuleError := err
 
 	b, err := json.Marshal(report)
 	if err != nil {
 		return nil, err
 	}
 
-	return bytes.NewBuffer(b), nil
+	return bytes.NewBuffer(b), missingRuleError
 }
 
 // FileExtension returns the file extension for this exporter's format

--- a/pkg/exporter/json_test.go
+++ b/pkg/exporter/json_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/yudai/gojsondiff/formatter"
 
 	"github.com/jetstack/preflight/pkg/packaging"
+	"github.com/jetstack/preflight/pkg/reports"
 	"github.com/jetstack/preflight/pkg/results"
 	"github.com/jetstack/preflight/pkg/rules"
 )
@@ -178,7 +179,7 @@ func TestJSONExport(t *testing.T) {
 }`
 
 	buf, err := jsonExporter.Export(context.Background(), pm, nil, rc)
-	if err != nil {
+	if _, ok := err.(*reports.MissingRegoDefinitionError); !ok {
 		t.Fatalf("unexpected err: %+v", err)
 	}
 

--- a/pkg/packaging/eval.go
+++ b/pkg/packaging/eval.go
@@ -27,10 +27,5 @@ func EvalPackage(ctx context.Context, pkg Package, input interface{}) (*results.
 		allResults = append(allResults, rs...)
 	}
 
-	rc, err := results.NewResultCollectionFromRegoResultSet(&allResults)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read results from rego: %s", err)
-	}
-
-	return rc, nil
+	return results.NewResultCollectionFromRegoResultSet(&allResults)
 }

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -168,5 +168,5 @@ type MissingRegoDefinitionError struct {
 }
 
 func (e *MissingRegoDefinitionError) Error() string {
-	return fmt.Sprintf("the following rules from the package %q are missing its Rego definition: %s", e.pkg, strings.Join(e.ids, ", "))
+	return fmt.Sprintf("the following rules from the package %q are missing their Rego definitions: %s", e.pkg, strings.Join(e.ids, ", "))
 }

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -245,74 +245,116 @@ func TestNewReport(t *testing.T) {
 						ID:   "b_rule",
 						Name: "My Rule B",
 					},
-					{
-						ID:   "c_rule",
-						Name: "My Rule C (missing)",
-					},
 				},
 			},
 		},
 	}
 
-	resultCollection := &results.ResultCollection{
-		&results.Result{ID: rules.RuleToResult("a_rule"), Violations: []string{}},
-		&results.Result{ID: rules.RuleToResult("b_rule"), Violations: []string{"violation"}},
-	}
+	t.Run("returns a report", func(t *testing.T) {
+		resultCollection := &results.ResultCollection{
+			&results.Result{ID: rules.RuleToResult("a_rule"), Violations: []string{}},
+			&results.Result{ID: rules.RuleToResult("b_rule"), Violations: []string{"violation"}},
+		}
 
-	got, err := NewReport(examplePackage, resultCollection)
-	if err != nil {
-		t.Fatalf("NewReport returned error: %v", err)
-	}
+		got, err := NewReport(examplePackage, resultCollection)
+		if err != nil {
+			t.Fatalf("NewReport returned error: %v", err)
+		}
 
-	want := api.Report{
-		PreflightVersion: version.PreflightVersion,
-		Package:          examplePackage.ID,
-		PackageInformation: api.PackageInformation{
-			Namespace:     examplePackage.Namespace,
-			ID:            examplePackage.ID,
-			Version:       examplePackage.PackageVersion,
-			SchemaVersion: examplePackage.SchemaVersion,
-		},
-		Name:        examplePackage.Name,
-		Description: examplePackage.Description,
-		Sections: []api.ReportSection{
-			api.ReportSection{
-				ID:   "a_section",
-				Name: "My section",
-				Rules: []api.ReportRule{
-					api.ReportRule{
-						ID:         "a_rule",
-						Name:       "My Rule A",
-						Manual:     false,
-						Success:    true,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{},
-					},
-					api.ReportRule{
-						ID:         "b_rule",
-						Name:       "My Rule B",
-						Manual:     false,
-						Success:    false,
-						Missing:    false,
-						Links:      []string{},
-						Violations: []string{"violation"},
-					},
-					api.ReportRule{
-						ID:         "c_rule",
-						Name:       "My Rule C (missing)",
-						Manual:     false,
-						Success:    false,
-						Missing:    true,
-						Links:      []string{},
-						Violations: []string{},
+		want := api.Report{
+			PreflightVersion: version.PreflightVersion,
+			Package:          examplePackage.ID,
+			PackageInformation: api.PackageInformation{
+				Namespace:     examplePackage.Namespace,
+				ID:            examplePackage.ID,
+				Version:       examplePackage.PackageVersion,
+				SchemaVersion: examplePackage.SchemaVersion,
+			},
+			Name:        examplePackage.Name,
+			Description: examplePackage.Description,
+			Sections: []api.ReportSection{
+				api.ReportSection{
+					ID:   "a_section",
+					Name: "My section",
+					Rules: []api.ReportRule{
+						api.ReportRule{
+							ID:         "a_rule",
+							Name:       "My Rule A",
+							Manual:     false,
+							Success:    true,
+							Missing:    false,
+							Links:      []string{},
+							Violations: []string{},
+						},
+						api.ReportRule{
+							ID:         "b_rule",
+							Name:       "My Rule B",
+							Manual:     false,
+							Success:    false,
+							Missing:    false,
+							Links:      []string{},
+							Violations: []string{"violation"},
+						},
 					},
 				},
 			},
-		},
-	}
+		}
 
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got != want; got=%+v, want=%+v", got, want)
-	}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got != want; got=%+v, want=%+v", got, want)
+		}
+	})
+
+	t.Run("returns error MissingRegoDefinitionError if definition missing", func(t *testing.T) {
+		resultCollection := &results.ResultCollection{
+			&results.Result{ID: rules.RuleToResult("a_rule"), Violations: []string{}},
+		}
+
+		got, err := NewReport(examplePackage, resultCollection)
+		if _, ok := err.(*MissingRegoDefinitionError); !ok {
+			t.Errorf("expected MissingRegoDefinitionError but got: %v", err)
+		}
+
+		want := api.Report{
+			PreflightVersion: version.PreflightVersion,
+			Package:          examplePackage.ID,
+			PackageInformation: api.PackageInformation{
+				Namespace: examplePackage.Namespace,
+				ID:        examplePackage.ID,
+				Version:   examplePackage.PackageVersion,
+			},
+			Name:        examplePackage.Name,
+			Description: examplePackage.Description,
+			Sections: []api.ReportSection{
+				api.ReportSection{
+					ID:   "a_section",
+					Name: "My section",
+					Rules: []api.ReportRule{
+						api.ReportRule{
+							ID:         "a_rule",
+							Name:       "My Rule A",
+							Manual:     false,
+							Success:    true,
+							Missing:    false,
+							Links:      []string{},
+							Violations: []string{},
+						},
+						api.ReportRule{
+							ID:         "b_rule",
+							Name:       "My Rule B",
+							Manual:     false,
+							Success:    false,
+							Missing:    true,
+							Links:      []string{},
+							Violations: []string{},
+						},
+					},
+				},
+			},
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got != want; got=%+v, want=%+v", got, want)
+		}
+	})
 }

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -319,9 +319,10 @@ func TestNewReport(t *testing.T) {
 			PreflightVersion: version.PreflightVersion,
 			Package:          examplePackage.ID,
 			PackageInformation: api.PackageInformation{
-				Namespace: examplePackage.Namespace,
-				ID:        examplePackage.ID,
-				Version:   examplePackage.PackageVersion,
+				Namespace:     examplePackage.Namespace,
+				ID:            examplePackage.ID,
+				Version:       examplePackage.PackageVersion,
+				SchemaVersion: examplePackage.SchemaVersion,
 			},
 			Name:        examplePackage.Name,
 			Description: examplePackage.Description,


### PR DESCRIPTION
This makes the command fail if a rule existed in the PolicyManifest but it was not found in the Rego package.

Since the reports are still useful, it does not fail hard and finished the execution after generating the reports.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>