### PR TITLE
Recreate enabledPackages slice so it is empty

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -313,6 +313,9 @@ func check() {
 	if err != nil {
 		log.Printf("unable to decode into struct, %v", err)
 		log.Print("using legacy enabled-packages format")
+		// The failed UnmarshalKey creates an EnabledPackage in the slice,
+		// so we recreate the slice here to make sure it's empty.
+		enabledPackages = []EnabledPackage{}
 		enabledPackageIDs := viper.GetStringSlice("enabled-packages")
 		for _, enabledPackageID := range enabledPackageIDs {
 			enabledPackages = append(enabledPackages, EnabledPackage{ID: enabledPackageID})


### PR DESCRIPTION
When reading the `enabled-packages` from config the if `UnmarshalKey` fails it creates an empty `EnabledPackage` in the slice. The slice is then populated using the legacy config style with `GetStringSlice`.

However later the empty `EnabledPackage` causes Preflight to exit with the error:
```
2020/02/03 16:24:43 Package with ID "" was specified in configuration but it wasn't found.
```

This fix recreates the slice when falling back to the legacy method to make sure it's empty before populating.

Signed-off-by: wwwil <wwwil.squires@gmail.com>