### PR TITLE
Add cluster and timestamp to summary

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -391,6 +391,9 @@ func check() {
 		if err != nil {
 			log.Fatalf("Cannot generate report for results: %v", err)
 		}
+		// at the moment, we need to add Cluster and Timestamp here because of #1.
+		report.Cluster = clusterName
+		report.Timestamp = api.Time{Time: checkTime}
 		packageReports = append(packageReports, report)
 
 		for _, output := range outputs {


### PR DESCRIPTION
We are not storing the timestamp nor the cluster name to the cluster summary.

This fix is not the best way of doing it. A better solution will come with #1.