### PR TITLE
Add minimal version of the agent command

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"log"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "start the preflight agent",
+	Long: `The agent will periodically gather data for the configured data
+	gatherers and send it to a remote backend for evaluation`,
+	Run: func(cmd *cobra.Command, args []string) {
+		for {
+			log.Printf("Running Agent... TODO")
+			time.Sleep(10 * time.Second)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(agentCmd)
+}

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"log"
-	"time"
+	"fmt"
 
+	"github.com/jetstack/preflight/pkg/agent"
 	"github.com/spf13/cobra"
 )
 
@@ -12,14 +12,15 @@ var agentCmd = &cobra.Command{
 	Short: "start the preflight agent",
 	Long: `The agent will periodically gather data for the configured data
 	gatherers and send it to a remote backend for evaluation`,
-	Run: func(cmd *cobra.Command, args []string) {
-		for {
-			log.Printf("Running Agent... TODO")
-			time.Sleep(10 * time.Second)
-		}
-	},
+	Run: agent.Run,
 }
 
 func init() {
 	rootCmd.AddCommand(agentCmd)
+	agentCmd.PersistentFlags().StringVarP(
+		&agent.ConfigFilePath,
+		"agent-config-file",
+		"c",
+		"./agent.yaml",
+		fmt.Sprintf("Config file location, default is `agent.yaml` in the current working directory"))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,12 @@ require (
 	github.com/gomarkdown/markdown v0.0.0-20191104174740-4d42851d4d5a
 	github.com/google/go-cmp v0.3.0
 	github.com/gookit/color v1.2.0
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9
 	github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 // indirect
 	github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b // indirect
+	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-ieproxy v0.0.0-20191113090002-7c0f6868bffe // indirect
 	github.com/open-policy-agent/opa v0.16.0
@@ -28,6 +30,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 	golang.org/x/sys v0.0.0-20200120151820-655fe14d7479 // indirect
 	google.golang.org/api v0.15.0
+	gopkg.in/d4l3k/messagediff.v1 v1.2.1
 	gopkg.in/yaml.v2 v2.2.7
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul v1.4.0/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
@@ -233,6 +234,7 @@ github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f/go.mod h1:5CU+a
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-memdb v0.0.0-20181108192425-032f93b25bec/go.mod h1:kbfItVoBJwCfKXDXN4YoAXjxcFVZ7MRrJzyTX6H4giE=
 github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-plugin v0.0.0-20181030172320-54b6ff97d818/go.mod h1:Ft7ju2vWzhO0ETMKUVo12XmXmII6eSUS4rsPTkY/siA=
 github.com/hashicorp/go-retryablehttp v0.5.0/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
@@ -307,6 +309,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.1.0 h1:Sm1gr51B1kKyfD2BlRcLSiEkffoG96g6TPv6eRoEiB8=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/leonelquinteros/gotext v1.4.0/go.mod h1:yZGXREmoGTtBvZHNcc+Yfug49G/2spuF/i/Qlsvz1Us=
@@ -659,6 +663,8 @@ gopkg.in/asn1-ber.v1 v1.0.0-20170511165959-379148ca0225/go.mod h1:cuepJuh7vyXfUy
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/d4l3k/messagediff.v1 v1.2.1 h1:70AthpjunwzUiarMHyED52mj9UwtAnE89l1Gmrt3EU0=
+gopkg.in/d4l3k/messagediff.v1 v1.2.1/go.mod h1:EUzikiKadqXWcD1AzJLagx0j/BeeWGtn++04Xniyg44=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"gopkg.in/yaml.v2"
+)
+
+// Config wraps the options for a run of the agent
+type Config struct {
+	Schedule      string         `yaml:"schedule"`
+	Token         string         `yaml:"token"`
+	Endpoint      endpoint       `yaml:"endpoint"`
+	DataGatherers []dataGatherer `yaml:"data-gatherers"`
+}
+
+type endpoint struct {
+	Host string `yaml:"host"`
+	Path string `yaml:"path"`
+}
+type dataGatherer struct {
+	Kind string            `yaml:"kind"`
+	Name string            `yaml:"name"`
+	Data map[string]string `yaml:"data"`
+}
+
+func (c *Config) validate() error {
+	var result *multierror.Error
+
+	if c.Token == "" {
+		result = multierror.Append(result, fmt.Errorf("token is required"))
+	}
+
+	if c.Schedule == "" {
+		result = multierror.Append(result, fmt.Errorf("schedule is required"))
+	}
+
+	if c.Endpoint.Host == "" {
+		result = multierror.Append(result, fmt.Errorf("endpoint host is required"))
+	}
+
+	if c.Endpoint.Path == "" {
+		result = multierror.Append(result, fmt.Errorf("endpoint path is required"))
+	}
+
+	for i, v := range c.DataGatherers {
+		if v.Kind == "" {
+			result = multierror.Append(result, fmt.Errorf("datagatherer %d/%d is missing a kind", i+1, len(c.DataGatherers)))
+		}
+		if v.Name == "" {
+			result = multierror.Append(result, fmt.Errorf("datagatherer %d/%d is missing a name", i+1, len(c.DataGatherers)))
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+// ParseConfig reads config into a struct used to configure running agents
+func ParseConfig(data []byte) (Config, error) {
+	var config Config
+
+	err := yaml.Unmarshal(data, &config)
+	if err != nil {
+		return config, err
+	}
+
+	return config, config.validate()
+}

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -23,6 +24,17 @@ type dataGatherer struct {
 	Kind string            `yaml:"kind"`
 	Name string            `yaml:"name"`
 	Data map[string]string `yaml:"data"`
+}
+
+// Dump generates a YAML string of the Config object
+func (c *Config) Dump() (string, error) {
+	d, err := yaml.Marshal(&c)
+
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate YAML dump of config")
+	}
+
+	return string(d), nil
 }
 
 func (c *Config) validate() error {

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -1,0 +1,134 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kylelemons/godebug/diff"
+	"gopkg.in/d4l3k/messagediff.v1"
+)
+
+func TestValidConfigLoad(t *testing.T) {
+	configFileContents := `
+      endpoint:
+        host: example.com
+        path: /api/v1/data
+      schedule: "* * * * *"
+      token: "12345"
+      data-gatherers:
+      - name: my-gke-cluster
+        kind: gke
+        data:
+          project: my-gcp-project
+          location: us-central1-a
+          cluster: my-gke-cluster
+      - name: my-pods
+        kind: k8s/pods
+        data:
+          kubeconfig: "~/.kube/config"`
+
+	loadedConfig, err := ParseConfig([]byte(configFileContents))
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	expected := Config{
+		Endpoint: endpoint{
+			Host: "example.com",
+			Path: "/api/v1/data",
+		},
+		Schedule: "* * * * *",
+		Token:    "12345",
+		DataGatherers: []dataGatherer{
+			dataGatherer{
+				Name: "my-gke-cluster",
+				Kind: "gke",
+				Data: map[string]string{
+					"project":  "my-gcp-project",
+					"location": "us-central1-a",
+					"cluster":  "my-gke-cluster",
+				},
+			},
+			dataGatherer{
+				Name: "my-pods",
+				Kind: "k8s/pods",
+				Data: map[string]string{
+					"kubeconfig": "~/.kube/config",
+				},
+			},
+		},
+	}
+
+	if diff, equal := messagediff.PrettyDiff(expected, loadedConfig); !equal {
+		t.Errorf("Diff %s", diff)
+	}
+}
+
+func TestInvalidConfigError(t *testing.T) {
+	configFileContents := `data-gatherers: "things"`
+
+	_, parseError := ParseConfig([]byte(configFileContents))
+
+	expectedError := fmt.Errorf("yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `things` into []agent.dataGatherer")
+
+	if parseError.Error() != expectedError.Error() {
+		t.Fatalf("got != want;\ngot=%s,\nwant=%s", parseError, expectedError)
+	}
+}
+
+func TestMissingConfigError(t *testing.T) {
+	_, parseError := ParseConfig([]byte(""))
+
+	if parseError == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	expectedErrorLines := []string{
+		"4 errors occurred:",
+		"\t* token is required",
+		"\t* schedule is required",
+		"\t* endpoint host is required",
+		"\t* endpoint path is required",
+		"\n",
+	}
+
+	expectedError := strings.Join(expectedErrorLines, "\n")
+
+	gotError := parseError.Error()
+
+	if gotError != expectedError {
+		t.Errorf("\ngot=\n%v\nwant=\n%s\ndiff=\n%s", gotError, expectedError, diff.Diff(gotError, expectedError))
+	}
+}
+
+func TestPartialMissingConfigError(t *testing.T) {
+	_, parseError := ParseConfig([]byte(`
+      endpoint:
+        host: example.com
+        path: /api/v1/data
+      schedule: "* * * * *"
+      token: "12345"
+      data-gatherers:
+        - foo: bar`))
+
+	if parseError == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	expectedErrorLines := []string{
+		"2 errors occurred:",
+		"\t* datagatherer 1/1 is missing a kind",
+		"\t* datagatherer 1/1 is missing a name",
+		"\n",
+	}
+
+	expectedError := strings.Join(expectedErrorLines, "\n")
+
+	gotError := parseError.Error()
+
+	if gotError != expectedError {
+		t.Errorf("\ngot=\n%v\nwant=\n%s\ndiff=\n%s", gotError, expectedError, diff.Diff(gotError, expectedError))
+	}
+}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// ConfigFilePath is where the agent will try to load the configuration from
+var ConfigFilePath string
+
+// Run starts the agent process
+func Run(cmd *cobra.Command, args []string) {
+	file, err := os.Open(ConfigFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load config file for agent from: %s", ConfigFilePath)
+	}
+	defer file.Close()
+
+	b, err := ioutil.ReadAll(file)
+
+	config, err := ParseConfig(b)
+	if err != nil {
+		log.Fatalf("Failed to parse config file: %s", err)
+	}
+
+	dump, err := config.Dump()
+	if err != nil {
+		log.Fatalf("Failed to dump config: %s", err)
+	}
+	log.Printf("Loaded config: \n%s", dump)
+
+	for {
+		log.Printf("Running Agent... TODO")
+		time.Sleep(10 * time.Second)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/jetstack/preflight/issues/85

Fixes https://github.com/jetstack/preflight/issues/86

This is my go at the most simple implementation of the above issues. We needed an agent with some config. All the config parts are in place to run datagatherers and upload data.

Why did I not use the existing preflight yaml? Wil is working on this today - I would have needed to add a more fields to the config. I might well end up using what Wil refactors but this allows the work on the agent to continue either way.