### PR TITLE
Custom unmarshaler for ClusterSummary

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -1,5 +1,7 @@
 package api
 
+import "encoding/json"
+
 // ClusterSummary contains a summary of the most recent status of a cluster.
 type ClusterSummary struct {
 	Cluster         string     `json:"cluster"`
@@ -23,4 +25,27 @@ type ReportSummary struct {
 	Timestamp    Time   `json:"-"`
 	FailureCount int    `json:"failureCount"`
 	SuccessCount int    `json:"successCount"`
+}
+
+// UnmarshalJSON unmarshals a ClusterSummary.
+func (c *ClusterSummary) UnmarshalJSON(data []byte) error {
+	type Alias ClusterSummary
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(c),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	c.LatestReportSet.Cluster = c.Cluster
+
+	for idx := range c.LatestReportSet.Reports {
+		c.LatestReportSet.Reports[idx].Cluster = c.LatestReportSet.Cluster
+		c.LatestReportSet.Reports[idx].Timestamp = c.LatestReportSet.Timestamp
+	}
+
+	return nil
 }

--- a/api/cluster_test.go
+++ b/api/cluster_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestClusterSummaryUnmarshalJSON(t *testing.T) {
+	data := `{
+  "cluster": "exampleCluster",
+  "latestReportSet": {
+    "timestamp": "2015-10-21T07:28:42Z",
+    "failureCount": 4,
+    "successCount": 1,
+    "reports": [
+      {
+        "id": "exampleReport1",
+        "package": "examplePackage.ID.1",
+        "failureCount": 2,
+        "successCount": 1
+      },
+      {
+        "id": "exampleReport2",
+        "package": "examplePackage.ID.2",
+        "failureCount": 2,
+        "successCount": 0
+      }
+    ]
+  }
+}`
+	ts, err := time.Parse(TimeFormat, "2015-10-21T07:28:42Z")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	want := ClusterSummary{
+		Cluster: "exampleCluster",
+		LatestReportSet: &ReportSet{
+			Cluster:      "exampleCluster",
+			Timestamp:    Time{Time: ts},
+			FailureCount: 4,
+			SuccessCount: 1,
+			Reports: []*ReportSummary{
+				&ReportSummary{
+					ID:           "exampleReport1",
+					Package:      "examplePackage.ID.1",
+					Cluster:      "exampleCluster",
+					Timestamp:    Time{Time: ts},
+					FailureCount: 2,
+					SuccessCount: 1,
+				},
+				&ReportSummary{
+					ID:           "exampleReport2",
+					Package:      "examplePackage.ID.2",
+					Cluster:      "exampleCluster",
+					Timestamp:    Time{Time: ts},
+					FailureCount: 2,
+					SuccessCount: 0,
+				},
+			},
+		},
+	}
+
+	var got ClusterSummary
+	err = json.Unmarshal([]byte(data), &got)
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got != want: got=%+v, want=%+v", got, want)
+	}
+}


### PR DESCRIPTION
This is needed to a `ClusterSummary` can be unmarshaled correctly just by doing `json.Unmarshal`.


Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>