### PR TITLE
Data gatherers config

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -157,7 +157,7 @@ func check() {
 
 				clusterName, _ := eksConfig["cluster"].(string)
 				dg, err = eks.NewDataGatherer(&eks.Config{
-					ClusterID: clusterName,
+					ClusterName: clusterName,
 				})
 				if err != nil {
 					log.Fatalf("Cannot instantiate EKS datagatherer: %v", err)
@@ -197,7 +197,7 @@ func check() {
 				credentialsPath, _ := aksConfig["credentials"].(string)
 				var err error
 				dg, err = aks.NewDataGatherer(&aks.Config{
-					ClusterID:       clusterName,
+					ClusterName:     clusterName,
 					ResourceGroup:   resourceGroup,
 					CredentialsPath: credentialsPath,
 				})

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -213,15 +213,17 @@ func check() {
 				if !ok {
 					log.Println("Didn't find 'kubeconfig' in 'data-gatherers.k8s/pods' configuration. Assuming it runs in-cluster.")
 				}
-				k8sClient, err := k8s.NewDynamicClient(expandHome(kubeconfigPath))
+				dg, err = k8s.NewDataGatherer(&k8s.Config{
+					KubeConfigPath: expandHome(kubeconfigPath),
+					GroupVersionResource: schema.GroupVersionResource{
+						Group:    "",
+						Version:  "v1",
+						Resource: "pods",
+					},
+				})
 				if err != nil {
 					log.Fatalf("Cannot create k8s client: %+v", err)
 				}
-				dg = k8s.NewGenericGatherer(k8sClient, schema.GroupVersionResource{
-					Group:    "",
-					Version:  "v1",
-					Resource: "pods",
-				})
 			} else if strings.HasPrefix(name, "k8s/") {
 				trimmed := strings.TrimPrefix(name, "k8s/")
 				nameOnDots := strings.SplitN(trimmed, ".", 3)
@@ -241,15 +243,17 @@ func check() {
 				if !ok {
 					log.Printf("Didn't find 'kubeconfig' in 'data-gatherers.%s' configuration. Assuming it runs in-cluster.", name)
 				}
-				k8sClient, err := k8s.NewDynamicClient(expandHome(kubeconfigPath))
+				dg, err = k8s.NewDataGatherer(&k8s.Config{
+					KubeConfigPath: expandHome(kubeconfigPath),
+					GroupVersionResource: schema.GroupVersionResource{
+						Resource: nameOnDots[0],
+						Version:  nameOnDots[1],
+						Group:    nameOnDots[2],
+					},
+				})
 				if err != nil {
 					log.Fatalf("Cannot create k8s client: %+v", err)
 				}
-				dg = k8s.NewGenericGatherer(k8sClient, schema.GroupVersionResource{
-					Resource: nameOnDots[0],
-					Version:  nameOnDots[1],
-					Group:    nameOnDots[2],
-				})
 			} else if name == "local" {
 				localConfig, ok := config.(map[string]interface{})
 				if !ok {

--- a/pkg/datagatherer/aks/aks.go
+++ b/pkg/datagatherer/aks/aks.go
@@ -13,8 +13,8 @@ import (
 
 // Config is the configuration for an AKS DataGatherer.
 type Config struct {
-	// ClusterID is the ID of the cluster in AKS.
-	ClusterID string
+	// ClusterName is the name of the cluster in AKS.
+	ClusterName string
 	// ResourceGroup is the resource group the cluster belongs to.
 	ResourceGroup string
 	// CredentialsPath is the path to the json file containing the credentials to access Azure APIs.
@@ -26,8 +26,8 @@ func (c *Config) Validate() error {
 	errs := []string{}
 
 	msg := "%s should be a non empty string."
-	if c.ClusterID == "" {
-		errs = append(errs, fmt.Sprintf(msg, "ClusterID"))
+	if c.ClusterName == "" {
+		errs = append(errs, fmt.Sprintf(msg, "ClusterName"))
 	}
 	if c.ResourceGroup == "" {
 		errs = append(errs, fmt.Sprintf(msg, "ResourceGroup"))
@@ -55,7 +55,7 @@ func NewDataGatherer(cfg *Config) (*DataGatherer, error) {
 
 	return &DataGatherer{
 		resourceGroup: cfg.ResourceGroup,
-		clusterID:     cfg.ClusterID,
+		clusterName:   cfg.ClusterName,
 		credentials:   credentials,
 	}, nil
 }
@@ -94,7 +94,7 @@ func readCredentials(path string) (*AzureCredentials, error) {
 // DataGatherer is a data-gatherer for AKS.
 type DataGatherer struct {
 	resourceGroup string
-	clusterID     string
+	clusterName   string
 	credentials   *AzureCredentials
 }
 
@@ -108,7 +108,7 @@ type Info struct {
 func (g *DataGatherer) Fetch() (interface{}, error) {
 	client := &http.Client{}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://management.azure.com/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s?api-version=2019-08-01", g.credentials.Subscription, g.resourceGroup, g.clusterID), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://management.azure.com/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s?api-version=2019-08-01", g.credentials.Subscription, g.resourceGroup, g.clusterName), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datagatherer/eks/eks.go
+++ b/pkg/datagatherer/eks/eks.go
@@ -11,14 +11,14 @@ import (
 
 // Config is the configuration for an EKS DataGatherer.
 type Config struct {
-	// ClusterID is the ID of the cluster in EKS.
-	ClusterID string
+	// ClusterName is the ID of the cluster in EKS.
+	ClusterName string
 }
 
 // Validate validates the configuration.
 func (c *Config) Validate() error {
-	if c.ClusterID == "" {
-		return fmt.Errorf("invalid configuration: ClusterID cannot be empty")
+	if c.ClusterName == "" {
+		return fmt.Errorf("invalid configuration: ClusterName cannot be empty")
 	}
 	return nil
 }
@@ -30,15 +30,15 @@ func NewDataGatherer(cfg *Config) (*DataGatherer, error) {
 	}
 
 	return &DataGatherer{
-		client:    eks.New(session.New()),
-		clusterID: cfg.ClusterID,
+		client:      eks.New(session.New()),
+		clustername: cfg.ClusterName,
 	}, nil
 }
 
 // DataGatherer is a data-gatherer for EKS.
 type DataGatherer struct {
-	client    *eks.EKS
-	clusterID string
+	client      *eks.EKS
+	clustername string
 }
 
 // Info contains the data retrieved from EKS.
@@ -50,7 +50,7 @@ type Info struct {
 // Fetch retrieves cluster information from EKS.
 func (g *DataGatherer) Fetch() (interface{}, error) {
 	input := &eks.DescribeClusterInput{
-		Name: aws.String(g.clusterID),
+		Name: aws.String(g.clustername),
 	}
 
 	result, err := g.client.DescribeCluster(input)

--- a/pkg/datagatherer/eks/eks.go
+++ b/pkg/datagatherer/eks/eks.go
@@ -2,6 +2,8 @@
 package eks
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/eks"
@@ -10,15 +12,27 @@ import (
 // Config is the configuration for an EKS DataGatherer.
 type Config struct {
 	// ClusterID is the ID of the cluster in EKS.
-	ClusterID string `mapstructure:"cluster-id"`
+	ClusterID string
+}
+
+// Validate validates the configuration.
+func (c *Config) Validate() error {
+	if c.ClusterID == "" {
+		return fmt.Errorf("invalid configuration: ClusterID cannot be empty")
+	}
+	return nil
 }
 
 // NewDataGatherer creates a new EKS DataGatherer.
-func NewDataGatherer(cfg *Config) *DataGatherer {
+func NewDataGatherer(cfg *Config) (*DataGatherer, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	return &DataGatherer{
 		client:    eks.New(session.New()),
 		clusterID: cfg.ClusterID,
-	}
+	}, nil
 }
 
 // DataGatherer is a data-gatherer for EKS.

--- a/pkg/datagatherer/gke/gke.go
+++ b/pkg/datagatherer/gke/gke.go
@@ -11,38 +11,49 @@ import (
 	"google.golang.org/api/option"
 )
 
-// GKEDataGatherer is a DataGatherer for GKE.
-type GKEDataGatherer struct {
+// Config is the configuration for a GKE DataGatherer.
+type Config struct {
+	// Cluster contains the details about to identify the cluster to gather information from.
+	Cluster *Cluster
+	// CredentialsPath is the path to the JSON file containing the credentials to authenticate against the GKE API.
+	CredentialsPath string
+}
+
+// Cluster holds details about the cluster required to query it using the API.
+type Cluster struct {
+	// Project is the Google Cloud Platform project the cluster belongs to.
+	Project string
+	// Deprecated: Zone of the cluster. Use Location instead.
+	Zone string
+	// Name is the identifier of the cluster.
+	Name string
+	// Location is the location of the cluster.
+	Location string
+}
+
+// DataGatherer is a DataGatherer for GKE.
+type DataGatherer struct {
 	ctx             context.Context
 	cluster         *Cluster
 	credentialsPath string
 }
 
-// GKEInfo contains the data retrieved from GKE.
-type GKEInfo struct {
+// Info contains the data retrieved from GKE.
+type Info struct {
 	Cluster *container.Cluster
 }
 
-// Cluster holds details about the cluster required to query it using the API.
-type Cluster struct {
-	Project string
-	// Zone is deprecated, since now Location works for both Zones and regions
-	Zone     string
-	Name     string
-	Location string
-}
-
-// NewGKEDataGatherer creates a new GKEDataGatherer for a cluster.
-func NewGKEDataGatherer(ctx context.Context, cluster *Cluster, credsPath string) *GKEDataGatherer {
-	return &GKEDataGatherer{
+// NewDataGatherer creates a new DataGatherer for a cluster.
+func NewDataGatherer(ctx context.Context, cfg *Config) *DataGatherer {
+	return &DataGatherer{
 		ctx:             ctx,
-		cluster:         cluster,
-		credentialsPath: credsPath,
+		cluster:         cfg.Cluster,
+		credentialsPath: cfg.CredentialsPath,
 	}
 }
 
 // Fetch retrieves cluster information from GKE.
-func (g *GKEDataGatherer) Fetch() (interface{}, error) {
+func (g *DataGatherer) Fetch() (interface{}, error) {
 	var credsOpt option.ClientOption
 	if len(g.credentialsPath) == 0 {
 		log.Println("Credentials path for GKE was not provided. Attempting to use GCP Workload Identity.")
@@ -75,7 +86,7 @@ func (g *GKEDataGatherer) Fetch() (interface{}, error) {
 		}
 	}
 
-	return &GKEInfo{
+	return &Info{
 		Cluster: cluster,
 	}, nil
 }

--- a/pkg/datagatherer/k8s/generic_test.go
+++ b/pkg/datagatherer/k8s/generic_test.go
@@ -89,7 +89,7 @@ func TestGenericGatherer_Fetch(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			cl := fake.NewSimpleDynamicClient(emptyScheme, test.objects...)
-			g := genericGatherer{
+			g := DataGatherer{
 				cl:                   cl,
 				groupVersionResource: test.gvr,
 				namespace:            test.namespace,

--- a/pkg/datagatherer/local/local.go
+++ b/pkg/datagatherer/local/local.go
@@ -1,11 +1,22 @@
 package local
 
-import "io/ioutil"
+import (
+	"fmt"
+	"io/ioutil"
+)
 
 // Config is the configuration for a local DataGatherer.
 type Config struct {
 	// DataPath is the path to file containing the data to load.
 	DataPath string
+}
+
+// Validate validates the configuration.
+func (c *Config) Validate() error {
+	if c.DataPath == "" {
+		return fmt.Errorf("invalid configuration: DataPath cannot be empty")
+	}
+	return nil
 }
 
 // DataGatherer is a data-gatherer that loads data from a local file.
@@ -14,10 +25,14 @@ type DataGatherer struct {
 }
 
 // NewDataGatherer returns a new DataGatherer.
-func NewDataGatherer(cfg *Config) *DataGatherer {
+func NewDataGatherer(cfg *Config) (*DataGatherer, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	return &DataGatherer{
 		dataPath: cfg.DataPath,
-	}
+	}, nil
 }
 
 // Fetch loads and returns the data from the LocalDatagatherer's dataPath

--- a/pkg/datagatherer/local/local.go
+++ b/pkg/datagatherer/local/local.go
@@ -2,19 +2,26 @@ package local
 
 import "io/ioutil"
 
-type LocalDataGatherer struct {
+// Config is the configuration for a local DataGatherer.
+type Config struct {
+	// DataPath is the path to file containing the data to load.
+	DataPath string
+}
+
+// DataGatherer is a data-gatherer that loads data from a local file.
+type DataGatherer struct {
 	dataPath string
 }
 
-// NewLocalDataGatherer returns a LocalDatagatherer with the dataPath provided.
-func NewLocalDataGatherer(dataPath string) *LocalDataGatherer {
-	return &LocalDataGatherer{
-		dataPath: dataPath,
+// NewDataGatherer returns a new DataGatherer.
+func NewDataGatherer(cfg *Config) *DataGatherer {
+	return &DataGatherer{
+		dataPath: cfg.DataPath,
 	}
 }
 
 // Fetch loads and returns the data from the LocalDatagatherer's dataPath
-func (g *LocalDataGatherer) Fetch() (interface{}, error) {
+func (g *DataGatherer) Fetch() (interface{}, error) {
 	dataBytes, err := ioutil.ReadFile(g.dataPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This offloads from #82 the formalization of the configuration for the datagatherers.

It also moves the responsibility of the validation to the data-gatherer package itself. If we finally end up refactoring the whole cmd/check config file parsing to rely on Viper's `mapstructure` annotations, we can make validation errors use the mapstructure tag ([see example](https://stackoverflow.com/questions/40864840/how-to-get-the-json-field-names-of-a-struct-in-golang)).

This is needed to unblock #95, although additional changes might be needed.