### PR TITLE
Use DataGatherer constructors as functions for the config

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -162,7 +162,7 @@ func check() {
 			// the name of the data gatherer it is impersonating so it can
 			// provide stubbed data.
 			if dataPath, ok := dataGathererConfig["data-path"].(string); ok && dataPath != "" {
-				dg, err = localdatagatherer.NewDataGatherer(&localdatagatherer.Config{DataPath: dataPath})
+				dg, err = (&localdatagatherer.Config{DataPath: dataPath}).NewDataGatherer(ctx)
 				if err != nil {
 					log.Fatalf("Cannot instantiate Local datagatherer impersonating %s: %v", name, err)
 				}
@@ -176,9 +176,9 @@ func check() {
 				}
 
 				clusterName, _ := eksConfig["cluster"].(string)
-				dg, err = eks.NewDataGatherer(&eks.Config{
+				dg, err = (&eks.Config{
 					ClusterName: clusterName,
-				})
+				}).NewDataGatherer(ctx)
 				if err != nil {
 					log.Fatalf("Cannot instantiate EKS datagatherer: %v", err)
 				}
@@ -194,7 +194,7 @@ func check() {
 				cluster, _ := gkeConfig["cluster"].(string)
 				credentialsPath, _ := gkeConfig["credentials"].(string)
 
-				dg, err = gke.NewDataGatherer(ctx, &gke.Config{
+				dg, err = (&gke.Config{
 					Cluster: &gke.Cluster{
 						Project:  project,
 						Zone:     zone,
@@ -202,7 +202,7 @@ func check() {
 						Name:     cluster,
 					},
 					CredentialsPath: credentialsPath,
-				})
+				}).NewDataGatherer(ctx)
 				if err != nil {
 					log.Fatalf("Cannot instantiate GKE datagatherer: %v", err)
 				}
@@ -216,11 +216,11 @@ func check() {
 				resourceGroup, _ := aksConfig["resource-group"].(string)
 				credentialsPath, _ := aksConfig["credentials"].(string)
 				var err error
-				dg, err = aks.NewDataGatherer(&aks.Config{
+				dg, err = (&aks.Config{
 					ClusterName:     clusterName,
 					ResourceGroup:   resourceGroup,
 					CredentialsPath: credentialsPath,
-				})
+				}).NewDataGatherer(ctx)
 				if err != nil {
 					log.Fatalf("Cannot instantiate AKS datagatherer: %v", err)
 				}
@@ -233,14 +233,14 @@ func check() {
 				if !ok {
 					log.Println("Didn't find 'kubeconfig' in 'data-gatherers.k8s/pods' configuration. Assuming it runs in-cluster.")
 				}
-				dg, err = k8s.NewDataGatherer(&k8s.Config{
+				dg, err = (&k8s.Config{
 					KubeConfigPath: pathutils.ExpandHome(kubeconfigPath),
 					GroupVersionResource: schema.GroupVersionResource{
 						Group:    "",
 						Version:  "v1",
 						Resource: "pods",
 					},
-				})
+				}).NewDataGatherer(ctx)
 				if err != nil {
 					log.Fatalf("Cannot create k8s client: %+v", err)
 				}
@@ -263,14 +263,14 @@ func check() {
 				if !ok {
 					log.Printf("Didn't find 'kubeconfig' in 'data-gatherers.%s' configuration. Assuming it runs in-cluster.", name)
 				}
-				dg, err = k8s.NewDataGatherer(&k8s.Config{
+				dg, err = (&k8s.Config{
 					KubeConfigPath: pathutils.ExpandHome(kubeconfigPath),
 					GroupVersionResource: schema.GroupVersionResource{
 						Resource: nameOnDots[0],
 						Version:  nameOnDots[1],
 						Group:    nameOnDots[2],
 					},
-				})
+				}).NewDataGatherer(ctx)
 				if err != nil {
 					log.Fatalf("Cannot create k8s client: %+v", err)
 				}
@@ -280,7 +280,7 @@ func check() {
 					log.Fatal("Cannot parse 'data-gatherers.local' in config.")
 				}
 				dataPath, ok := localConfig["data-path"].(string)
-				dg, err = localdatagatherer.NewDataGatherer(&localdatagatherer.Config{DataPath: dataPath})
+				dg, err = (&localdatagatherer.Config{DataPath: dataPath}).NewDataGatherer(ctx)
 				if err != nil {
 					log.Fatalf("Cannot instantiate Local datagatherer: %v", err)
 				}

--- a/pkg/datagatherer/aks/aks.go
+++ b/pkg/datagatherer/aks/aks.go
@@ -2,6 +2,7 @@
 package aks
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -21,8 +22,8 @@ type Config struct {
 	CredentialsPath string
 }
 
-// Validate checks if a Config is valid.
-func (c *Config) Validate() error {
+// validate checks if a Config is valid.
+func (c *Config) validate() error {
 	errs := []string{}
 
 	msg := "%s should be a non empty string."
@@ -43,19 +44,19 @@ func (c *Config) Validate() error {
 }
 
 // NewDataGatherer creates a new AKS DataGatherer. It performs a config validation.
-func NewDataGatherer(cfg *Config) (*DataGatherer, error) {
-	if err := cfg.Validate(); err != nil {
+func (c *Config) NewDataGatherer(ctx context.Context) (*DataGatherer, error) {
+	if err := c.validate(); err != nil {
 		return nil, err
 	}
 
-	credentials, err := readCredentials(cfg.CredentialsPath)
+	credentials, err := readCredentials(c.CredentialsPath)
 	if err != nil {
 		return nil, err
 	}
 
 	return &DataGatherer{
-		resourceGroup: cfg.ResourceGroup,
-		clusterName:   cfg.ClusterName,
+		resourceGroup: c.ResourceGroup,
+		clusterName:   c.ClusterName,
 		credentials:   credentials,
 	}, nil
 }

--- a/pkg/datagatherer/datagatherer.go
+++ b/pkg/datagatherer/datagatherer.go
@@ -1,6 +1,14 @@
 // Package datagatherer provides the DataGatherer interface.
 package datagatherer
 
+import "context"
+
+// Config is the configuration of a DataGatherer.
+type Config interface {
+	// NewDataGatherer constructs a DataGatherer with an specific configuration.
+	NewDataGatherer(ctx context.Context) (DataGatherer, error)
+}
+
 // DataGatherer is the interface for Data Gatherers. Data Gatherers are in charge of fetching data from a certain cloud provider API or Kubernetes component.
 type DataGatherer interface {
 	// Fetch retrieves data.

--- a/pkg/datagatherer/eks/eks.go
+++ b/pkg/datagatherer/eks/eks.go
@@ -2,6 +2,7 @@
 package eks
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,23 +16,23 @@ type Config struct {
 	ClusterName string
 }
 
-// Validate validates the configuration.
-func (c *Config) Validate() error {
+// validate validates the configuration.
+func (c *Config) validate() error {
 	if c.ClusterName == "" {
 		return fmt.Errorf("invalid configuration: ClusterName cannot be empty")
 	}
 	return nil
 }
 
-// NewDataGatherer creates a new EKS DataGatherer.
-func NewDataGatherer(cfg *Config) (*DataGatherer, error) {
-	if err := cfg.Validate(); err != nil {
+// NewDataGatherer creates a new EKS DataGatherer. It performs a config validation.
+func (c *Config) NewDataGatherer(ctx context.Context) (*DataGatherer, error) {
+	if err := c.validate(); err != nil {
 		return nil, err
 	}
 
 	return &DataGatherer{
 		client:      eks.New(session.New()),
-		clustername: cfg.ClusterName,
+		clustername: c.ClusterName,
 	}, nil
 }
 

--- a/pkg/datagatherer/gke/gke.go
+++ b/pkg/datagatherer/gke/gke.go
@@ -20,8 +20,8 @@ type Config struct {
 	CredentialsPath string
 }
 
-// Validate validates the configuration.
-func (c *Config) Validate() error {
+// validate validates the configuration.
+func (c *Config) validate() error {
 	errs := []string{}
 	emptyMsg := "%s should be a non empty string"
 
@@ -72,15 +72,15 @@ type Info struct {
 }
 
 // NewDataGatherer creates a new DataGatherer for a cluster.
-func NewDataGatherer(ctx context.Context, cfg *Config) (*DataGatherer, error) {
-	if err := cfg.Validate(); err != nil {
+func (c *Config) NewDataGatherer(ctx context.Context) (*DataGatherer, error) {
+	if err := c.validate(); err != nil {
 		return nil, err
 	}
 
 	return &DataGatherer{
 		ctx:             ctx,
-		cluster:         cfg.Cluster,
-		credentialsPath: cfg.CredentialsPath,
+		cluster:         c.Cluster,
+		credentialsPath: c.CredentialsPath,
 	}, nil
 }
 

--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -17,8 +18,8 @@ type Config struct {
 	GroupVersionResource schema.GroupVersionResource
 }
 
-// Validate validates the configuration.
-func (c *Config) Validate() error {
+// validate validates the configuration.
+func (c *Config) validate() error {
 	if c.GroupVersionResource.Resource == "" {
 		return fmt.Errorf("invalid configuration: GroupVersionResource.Resource cannot be empty")
 	}
@@ -28,19 +29,19 @@ func (c *Config) Validate() error {
 
 // NewDataGatherer constructs a new instance of the generic K8s data-gatherer for the provided
 // GroupVersionResource.
-func NewDataGatherer(cfg *Config) (*DataGatherer, error) {
-	if err := cfg.Validate(); err != nil {
+func (c *Config) NewDataGatherer(ctx context.Context) (*DataGatherer, error) {
+	if err := c.validate(); err != nil {
 		return nil, err
 	}
 
-	cl, err := NewDynamicClient(cfg.KubeConfigPath)
+	cl, err := NewDynamicClient(c.KubeConfigPath)
 	if err != nil {
 		return nil, err
 	}
 
 	return &DataGatherer{
 		cl:                   cl,
-		groupVersionResource: cfg.GroupVersionResource,
+		groupVersionResource: c.GroupVersionResource,
 	}, nil
 }
 

--- a/pkg/datagatherer/local/local.go
+++ b/pkg/datagatherer/local/local.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 )
@@ -11,8 +12,8 @@ type Config struct {
 	DataPath string
 }
 
-// Validate validates the configuration.
-func (c *Config) Validate() error {
+// validate validates the configuration.
+func (c *Config) validate() error {
 	if c.DataPath == "" {
 		return fmt.Errorf("invalid configuration: DataPath cannot be empty")
 	}
@@ -25,13 +26,13 @@ type DataGatherer struct {
 }
 
 // NewDataGatherer returns a new DataGatherer.
-func NewDataGatherer(cfg *Config) (*DataGatherer, error) {
-	if err := cfg.Validate(); err != nil {
+func (c *Config) NewDataGatherer(ctx context.Context) (*DataGatherer, error) {
+	if err := c.validate(); err != nil {
 		return nil, err
 	}
 
 	return &DataGatherer{
-		dataPath: cfg.DataPath,
+		dataPath: c.DataPath,
 	}, nil
 }
 


### PR DESCRIPTION
This keeps the spirit of #101 and allows us to create DataGatherers programmatically in #95.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>