### PR TITLE
Refactor config decoding in check function

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -34,7 +34,7 @@ import (
 	"github.com/jetstack/preflight/pkg/results"
 )
 
-var cfgFile string
+var configPath string
 
 // GlobalConfigDirectory is a static path where configuration
 // may be loaded from. This is designed to support this
@@ -59,7 +59,7 @@ This command will never modify external resources, and is safe to run idempotent
 func init() {
 	rootCmd.AddCommand(checkCmd)
 	checkCmd.PersistentFlags().StringVarP(
-		&cfgFile,
+		&configPath,
 		"config-file",
 		"c",
 		"",
@@ -67,8 +67,8 @@ func init() {
 }
 
 func loadConfigFile() {
-	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
+	if configPath != "" {
+		viper.SetConfigFile(configPath)
 	} else {
 		currentWorkingDirectory, err := os.Getwd()
 		// Ignore any errors silently, but only search the

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -162,57 +162,39 @@ func check() {
 		log.Fatalf("No Packages loaded")
 	}
 
-	// Load datagatherers
-	gatherers := make(map[string]datagatherer.DataGatherer)
-	gatherersConfig, ok := viper.Get("data-gatherers").(map[string]interface{})
+	// Decode data gatherer config
+	var dataGatherersConfig map[string]datagatherer.Config
+	dataGatherersConfigFromFile, ok := viper.Get("data-gatherers").(map[string]interface{})
 	// we don't error if no data-gatherers to keep backwards compatibility
 	if ok {
-		for name, config := range gatherersConfig {
-			// TODO: create gatherer from config in a more clever way. We need to read gatherer config from here and its schema depends on the gatherer itself.
-			var dg datagatherer.DataGatherer
-			var err error
-			dataGathererConfig, ok := config.(map[string]interface{})
+		for name, dataGathererConfigFromFile := range dataGatherersConfigFromFile {
+			// TODO: create gatherer from config in a more clever way.
+			// We need to read gatherer config from here and its schema depends on the gatherer itself.
+			dataGathererConfigMap, ok := dataGathererConfigFromFile.(map[string]interface{})
 			if !ok {
 				log.Fatalf("Cannot parse %s data gatherer config.", name)
 			}
+			var dataGathererConfig datagatherer.Config
 			// Check if this data gatherer's config specifies a data-path.
 			// If it does create a LocalDataGatherer to load this data but keep
 			// the name of the data gatherer it is impersonating so it can
 			// provide stubbed data.
-			if dataPath, ok := dataGathererConfig["data-path"].(string); ok && dataPath != "" {
-				dg, err = (&localdatagatherer.Config{DataPath: dataPath}).NewDataGatherer(ctx)
-				if err != nil {
-					log.Fatalf("Cannot instantiate Local datagatherer impersonating %s: %v", name, err)
+			if dataPath, ok := dataGathererConfigMap["data-path"].(string); ok && dataPath != "" {
+				dataGathererConfig = &localdatagatherer.Config{
+					DataPath: dataPath,
 				}
-				gatherers[name] = dg
-				continue
-			}
-			if name == "eks" {
-				eksConfig, ok := config.(map[string]interface{})
-				if !ok {
-					log.Fatal("Cannot parse 'data-gatherers.eks' in config.")
-				}
-
-				clusterName, _ := eksConfig["cluster"].(string)
-				dg, err = (&eks.Config{
+			} else if name == "eks" {
+				clusterName, _ := dataGathererConfigMap["cluster"].(string)
+				dataGathererConfig = &eks.Config{
 					ClusterName: clusterName,
-				}).NewDataGatherer(ctx)
-				if err != nil {
-					log.Fatalf("Cannot instantiate EKS datagatherer: %v", err)
 				}
 			} else if name == "gke" {
-				gkeConfig, ok := config.(map[string]interface{})
-				if !ok {
-					log.Fatal("Cannot parse 'data-gatherers.gke' in config.")
-				}
-
-				project, _ := gkeConfig["project"].(string)
-				zone, _ := gkeConfig["zone"].(string)
-				location, _ := gkeConfig["location"].(string)
-				cluster, _ := gkeConfig["cluster"].(string)
-				credentialsPath, _ := gkeConfig["credentials"].(string)
-
-				dg, err = (&gke.Config{
+				project, _ := dataGathererConfigMap["project"].(string)
+				zone, _ := dataGathererConfigMap["zone"].(string)
+				location, _ := dataGathererConfigMap["location"].(string)
+				cluster, _ := dataGathererConfigMap["cluster"].(string)
+				credentialsPath, _ := dataGathererConfigMap["credentials"].(string)
+				dataGathererConfig = &gke.Config{
 					Cluster: &gke.Cluster{
 						Project:  project,
 						Zone:     zone,
@@ -220,47 +202,28 @@ func check() {
 						Name:     cluster,
 					},
 					CredentialsPath: credentialsPath,
-				}).NewDataGatherer(ctx)
-				if err != nil {
-					log.Fatalf("Cannot instantiate GKE datagatherer: %v", err)
 				}
 			} else if name == "aks" {
-				aksConfig, ok := config.(map[string]interface{})
-				if !ok {
-					log.Fatal("Cannot parse 'data-gatherers.aks' in config.")
-				}
-
-				clusterName, _ := aksConfig["cluster"].(string)
-				resourceGroup, _ := aksConfig["resource-group"].(string)
-				credentialsPath, _ := aksConfig["credentials"].(string)
-				var err error
-				dg, err = (&aks.Config{
+				clusterName, _ := dataGathererConfigMap["cluster"].(string)
+				resourceGroup, _ := dataGathererConfigMap["resource-group"].(string)
+				credentialsPath, _ := dataGathererConfigMap["credentials"].(string)
+				dataGathererConfig = &aks.Config{
 					ClusterName:     clusterName,
 					ResourceGroup:   resourceGroup,
 					CredentialsPath: credentialsPath,
-				}).NewDataGatherer(ctx)
-				if err != nil {
-					log.Fatalf("Cannot instantiate AKS datagatherer: %v", err)
 				}
 			} else if name == "k8s/pods" {
-				podsConfig, ok := config.(map[string]interface{})
-				if !ok {
-					log.Fatal("Cannot parse 'data-gatherers.k8s/pods' in config.")
-				}
-				kubeconfigPath, ok := podsConfig["kubeconfig"].(string)
+				kubeconfigPath, ok := dataGathererConfigMap["kubeconfig"].(string)
 				if !ok {
 					log.Println("Didn't find 'kubeconfig' in 'data-gatherers.k8s/pods' configuration. Assuming it runs in-cluster.")
 				}
-				dg, err = (&k8s.Config{
+				dataGathererConfig = &k8s.Config{
 					KubeConfigPath: pathutils.ExpandHome(kubeconfigPath),
 					GroupVersionResource: schema.GroupVersionResource{
 						Group:    "",
 						Version:  "v1",
 						Resource: "pods",
 					},
-				}).NewDataGatherer(ctx)
-				if err != nil {
-					log.Fatalf("Cannot create k8s client: %+v", err)
 				}
 			} else if strings.HasPrefix(name, "k8s/") {
 				trimmed := strings.TrimPrefix(name, "k8s/")
@@ -273,45 +236,46 @@ func check() {
 				if len(nameOnDots) != 3 {
 					log.Fatal("Failed to parse generic k8s plugin configuration. Expected data gatherer name of the form k8s/{resource-name}.{api-version}.{api-group}")
 				}
-				config, ok := config.(map[string]interface{})
-				if !ok {
-					log.Fatalf("cannot parse 'data-gatherers.%s' in config.", name)
-				}
-				kubeconfigPath, ok := config["kubeconfig"].(string)
+				kubeconfigPath, ok := dataGathererConfigMap["kubeconfig"].(string)
 				if !ok {
 					log.Printf("Didn't find 'kubeconfig' in 'data-gatherers.%s' configuration. Assuming it runs in-cluster.", name)
 				}
-				dg, err = (&k8s.Config{
+				dataGathererConfig = &k8s.Config{
 					KubeConfigPath: pathutils.ExpandHome(kubeconfigPath),
 					GroupVersionResource: schema.GroupVersionResource{
 						Resource: nameOnDots[0],
 						Version:  nameOnDots[1],
 						Group:    nameOnDots[2],
 					},
-				}).NewDataGatherer(ctx)
-				if err != nil {
-					log.Fatalf("Cannot create k8s client: %+v", err)
 				}
 			} else if name == "local" {
-				localConfig, ok := config.(map[string]interface{})
+				dataPath, ok := dataGathererConfigMap["data-path"].(string)
 				if !ok {
-					log.Fatal("Cannot parse 'data-gatherers.local' in config.")
+					log.Fatalf("Didn't find 'data-path' in 'data-gatherers.%s' configuration.", name)
 				}
-				dataPath, ok := localConfig["data-path"].(string)
-				dg, err = (&localdatagatherer.Config{DataPath: dataPath}).NewDataGatherer(ctx)
-				if err != nil {
-					log.Fatalf("Cannot instantiate Local datagatherer: %v", err)
+				dataGathererConfig = &localdatagatherer.Config{
+					DataPath: dataPath,
 				}
 			} else {
 				log.Fatalf("Found unsupported data-gatherer %q in config.", name)
 			}
-			gatherers[name] = dg
+			dataGatherersConfig[name] = dataGathererConfig
 		}
+	}
+
+	// Load data gatherers
+	dataGatherers := make(map[string]datagatherer.DataGatherer)
+	for name, config := range dataGatherersConfig {
+		dg, err := config.NewDataGatherer(ctx)
+		if err != nil {
+			log.Fatalf("Cannot instantiate %s datagatherer: %v", name, err)
+		}
+		dataGatherers[name] = dg
 	}
 
 	// Fetch from all datagatherers
 	information := make(map[string]interface{})
-	for k, g := range gatherers {
+	for k, g := range dataGatherers {
 		i, err := g.Fetch()
 		if err != nil {
 			log.Fatalf("Error fetching with DataGatherer %q: %s", k, err)
@@ -446,7 +410,7 @@ func check() {
 		manifest := pkg.PolicyManifest
 		// Make sure we loaded the DataGatherers.
 		for _, g := range manifest.DataGatherers {
-			if gatherers[g] == nil {
+			if dataGatherers[g] == nil {
 				log.Fatalf("Package with ID %q requires DataGatherer %q, but it is not configured.", pkg.PolicyManifest.ID, g)
 			}
 		}


### PR DESCRIPTION
This PR refactors `cmd.check.go` to separate the decoding of config from the instantiation of items.

It is intended to be a precursor to moving the config loading and decoding out of the main `check` function and using a`Config` stuct.