### PR TITLE
Embed ReportMetadata into Report

### DIFF
--- a/api/report.go
+++ b/api/report.go
@@ -2,19 +2,8 @@ package api
 
 // Report contains the fields of a Preflight report
 type Report struct {
-	// Unique ID of the report.
-	ID string `json:"id"`
-	// PreflightVersion indicates the version of preflight this report was generated with.
-	PreflightVersion string `json:"preflight-version"`
-	// Timestamp indicates when the report was generated.
-	Timestamp Time `json:"timestamp"`
-	// Cluster indicates which was the target of the report.
-	Cluster string `json:"cluster"`
-	// Package indicates which package was used for the report. (deprecated)
-	Package string `json:"package"`
-	// PackageInformation contains all the information about the package that was used to generate the report.
-	PackageInformation PackageInformation `json:"package-information"`
-	// Name is the name of the package that was used for this report.
+	ReportMetadata
+	// Deprecated: Name is the name of the package that was used for this report.
 	Name string `json:"name"`
 	// Description is the description of the package that was used for this report.
 	Description string `json:"description,omitempty"`
@@ -43,6 +32,11 @@ func (r *Report) Summarize() ReportSummary {
 		FailureCount: failures,
 		SuccessCount: successes,
 	}
+}
+
+// GetMetadata gets the metadata of the report
+func (r *Report) GetMetadata() *ReportMetadata {
+	return &r.ReportMetadata
 }
 
 // PackageInformation contains all the details to identify a package.
@@ -101,7 +95,7 @@ type ReportMetadata struct {
 	Timestamp Time `json:"timestamp"`
 	// Cluster indicates which was the target of the report.
 	Cluster string `json:"cluster"`
-	// Package indicates which package was used for the report. (deprecated)
+	// Deprecated: Package indicates which package was used for the report.
 	Package string `json:"package"`
 	// PackageInformation contains all the information about the package that was used to generate the report.
 	PackageInformation PackageInformation `json:"package-information"`

--- a/pkg/reports/reports.go
+++ b/pkg/reports/reports.go
@@ -79,13 +79,15 @@ func NewReportSet(reports []api.Report) (api.ReportSet, error) {
 func NewReport(pm *packaging.PolicyManifest, rc *results.ResultCollection) (api.Report, error) {
 	report := api.Report{
 		// TODO: we are omitting ID, Timestamp and Cluster for now, but it will get fixed with #1
-		PreflightVersion: version.PreflightVersion,
-		Package:          pm.ID,
-		PackageInformation: api.PackageInformation{
-			Namespace:     pm.Namespace,
-			ID:            pm.ID,
-			Version:       pm.PackageVersion,
-			SchemaVersion: pm.SchemaVersion,
+		ReportMetadata: api.ReportMetadata{
+			PreflightVersion: version.PreflightVersion,
+			Package:          pm.ID,
+			PackageInformation: api.PackageInformation{
+				Namespace:     pm.Namespace,
+				ID:            pm.ID,
+				Version:       pm.PackageVersion,
+				SchemaVersion: pm.SchemaVersion,
+			},
 		},
 		Name:        pm.Name,
 		Description: pm.Description,

--- a/pkg/reports/reports_test.go
+++ b/pkg/reports/reports_test.go
@@ -14,17 +14,19 @@ import (
 )
 
 var fixtureReport1 = api.Report{
-	ID:               "fixtureReport1",
-	PreflightVersion: "version.PreflightVersion",
-	Package:          "examplePackage.ID",
-	PackageInformation: api.PackageInformation{
-		Namespace: "examplePackage.Namespace",
-		ID:        "examplePackage.ID",
-		Version:   "examplePackage.PackageVersion",
+	ReportMetadata: api.ReportMetadata{
+		ID:               "fixtureReport1",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Cluster: "exampleCluster",
 	},
 	Name:        "examplePackage.Name",
 	Description: "examplePackage.Description",
-	Cluster:     "exampleCluster",
 	Sections: []api.ReportSection{
 		api.ReportSection{
 			ID:   "a_section",
@@ -63,17 +65,19 @@ var fixtureReport1 = api.Report{
 }
 
 var fixtureReport2 = api.Report{
-	ID:               "fixtureReport2",
-	PreflightVersion: "version.PreflightVersion",
-	Package:          "examplePackage.ID",
-	PackageInformation: api.PackageInformation{
-		Namespace: "examplePackage.Namespace",
-		ID:        "examplePackage.ID",
-		Version:   "examplePackage.PackageVersion",
+	ReportMetadata: api.ReportMetadata{
+		ID:               "fixtureReport2",
+		PreflightVersion: "version.PreflightVersion",
+		Package:          "examplePackage.ID",
+		PackageInformation: api.PackageInformation{
+			Namespace: "examplePackage.Namespace",
+			ID:        "examplePackage.ID",
+			Version:   "examplePackage.PackageVersion",
+		},
+		Cluster: "exampleCluster",
 	},
 	Name:        "examplePackage.Name",
 	Description: "examplePackage.Description",
-	Cluster:     "exampleCluster",
 	Sections: []api.ReportSection{
 		api.ReportSection{
 			ID:   "a_section",
@@ -267,13 +271,15 @@ func TestNewReport(t *testing.T) {
 		}
 
 		want := api.Report{
-			PreflightVersion: version.PreflightVersion,
-			Package:          examplePackage.ID,
-			PackageInformation: api.PackageInformation{
-				Namespace:     examplePackage.Namespace,
-				ID:            examplePackage.ID,
-				Version:       examplePackage.PackageVersion,
-				SchemaVersion: examplePackage.SchemaVersion,
+			ReportMetadata: api.ReportMetadata{
+				PreflightVersion: version.PreflightVersion,
+				Package:          examplePackage.ID,
+				PackageInformation: api.PackageInformation{
+					Namespace:     examplePackage.Namespace,
+					ID:            examplePackage.ID,
+					Version:       examplePackage.PackageVersion,
+					SchemaVersion: examplePackage.SchemaVersion,
+				},
 			},
 			Name:        examplePackage.Name,
 			Description: examplePackage.Description,
@@ -330,13 +336,15 @@ func TestNewReport(t *testing.T) {
 		}
 
 		want := api.Report{
-			PreflightVersion: version.PreflightVersion,
-			Package:          examplePackage.ID,
-			PackageInformation: api.PackageInformation{
-				Namespace:     examplePackage.Namespace,
-				ID:            examplePackage.ID,
-				Version:       examplePackage.PackageVersion,
-				SchemaVersion: examplePackage.SchemaVersion,
+			ReportMetadata: api.ReportMetadata{
+				PreflightVersion: version.PreflightVersion,
+				Package:          examplePackage.ID,
+				PackageInformation: api.PackageInformation{
+					Namespace:     examplePackage.Namespace,
+					ID:            examplePackage.ID,
+					Version:       examplePackage.PackageVersion,
+					SchemaVersion: examplePackage.SchemaVersion,
+				},
 			},
 			Name:        examplePackage.Name,
 			Description: examplePackage.Description,


### PR DESCRIPTION
This avoids some repetition and makes it easy to retrieve the metadata of a report without implementing new helpers.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>