### PR TITLE
k8s: allow setting KUBECONFIG to use via environment variable

### DIFF
--- a/pkg/datagatherer/k8s/client.go
+++ b/pkg/datagatherer/k8s/client.go
@@ -4,21 +4,47 @@ package k8s
 import (
 	"github.com/pkg/errors"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 // NewDynamicClient creates a new 'dynamic' clientset using the provided kubeconfig.
-// If kubeconfigPath is not set/empty, it will attempt to load the InClusterConfig.
+// If kubeconfigPath is not set/empty, it will attempt to load configuration using
+// the default loading rules.
 func NewDynamicClient(kubeconfigPath string) (dynamic.Interface, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	cfg, err := loadRESTConfig(kubeconfigPath)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-
-	cl, err := dynamic.NewForConfig(config)
+	cl, err := dynamic.NewForConfig(cfg)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-
 	return cl, nil
+}
+
+func loadRESTConfig(path string) (*rest.Config, error) {
+	switch path {
+	// If the kubeconfig path is not provided, use the default loading rules
+	// so we read the regular KUBECONFIG variable.
+	case "":
+		apicfg, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		cfg, err := clientcmd.NewDefaultClientConfig(*apicfg, &clientcmd.ConfigOverrides{}).ClientConfig()
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return cfg, nil
+	// Otherwise use the explicitly named kubeconfig file.
+	default:
+		cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
+			&clientcmd.ConfigOverrides{}).ClientConfig()
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return cfg, nil
+	}
 }

--- a/pkg/datagatherer/k8s/client_test.go
+++ b/pkg/datagatherer/k8s/client_test.go
@@ -1,0 +1,77 @@
+package k8s
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+)
+
+// These tests do not currently validate the created dynamic client uses the
+// KUBECONFIG file that we create, however it _does_ exercise enough of the
+// code path to show that the function is correctly selecting which file to
+// load and returning it.
+
+func TestNewDynamicClient_ExplicitKubeconfig(t *testing.T) {
+	kc := createValidTestConfig()
+	path := writeConfigToFile(t, kc)
+	_, err := NewDynamicClient(path)
+	if err != nil {
+		t.Error("failed to create client: ", err)
+	}
+}
+
+func TestNewDynamicClient_InferredKubeconfig(t *testing.T) {
+	kc := createValidTestConfig()
+	path := writeConfigToFile(t, kc)
+	cleanupFn := temporarilySetEnv("KUBECONFIG", path)
+	defer cleanupFn()
+	_, err := NewDynamicClient("")
+	if err != nil {
+		t.Error("failed to create client: ", err)
+	}
+}
+
+func writeConfigToFile(t *testing.T, cfg clientcmdapi.Config) string {
+	f, err := ioutil.TempFile("", "testcase-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := clientcmdlatest.Codec.Encode(&cfg, f); err != nil {
+		t.Fatal(err)
+	}
+	return f.Name()
+}
+
+func createValidTestConfig() clientcmdapi.Config {
+	const (
+		server = "https://example.com:8080"
+		token  = "the-token"
+	)
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server: server,
+	}
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		Token: token,
+	}
+	config.Contexts["clean"] = &clientcmdapi.Context{
+		Cluster:  "clean",
+		AuthInfo: "clean",
+	}
+	config.CurrentContext = "clean"
+
+	return *config
+}
+
+func temporarilySetEnv(key, value string) func() {
+	old := os.Getenv(key)
+	os.Setenv(key, value)
+	return func() {
+		os.Setenv(key, old)
+	}
+}


### PR DESCRIPTION
This allows users to omit the `kubeconfig` field from their config files, instead opting to use their default configured kubeconfig file (as per typical kubectl loading rules).

I've also added a very basic test that exercises these two codepaths. Without breaking out the config loading piece into its own function, this seemed like a nice and quick way to check things work (albeit it *doesn't* validate the the *expected* config file is being loaded, only that one _is_ loaded).