### PR TITLE
Redact Kubernetes Secret data

### DIFF
--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -131,17 +131,13 @@ func redactList(list *unstructured.UnstructuredList) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		redactItem := false
 		for _, gvk := range gvks {
 			// If this item is a Secret then we need to redact it.
 			if gvk.Kind == "Secret" {
-				redactItem = true
+				// Redact the Secret by overwriting its data.
+				list.Items[i].Object["data"] = map[string]interface{}{}
 				break
 			}
-		}
-		// Redcat the Secret by overwriting its data.
-		if redactItem {
-			list.Items[i].Object["data"] = map[string]interface{}{}
 		}
 	}
 	return nil

--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -112,7 +112,7 @@ func (g *DataGatherer) Fetch() (interface{}, error) {
 		return nil, errors.WithStack(err)
 	}
 	// Redact Secret data
-	if strings.ToLower(g.groupVersionResource.Resource) == "secret" {
+	if strings.ToLower(g.groupVersionResource.Resource) == "secrets" {
 		for i := range list.Items {
 			list.Items[i].Object["data"] = map[string]interface{}{}
 		}

--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -127,7 +127,7 @@ func redactList(list *unstructured.UnstructuredList) error {
 	// Iterate over the items in the list.
 	for i := range list.Items {
 		// Determine the kind of items in case this is a generic 'mixed' list.
-		gvks, _, err := scheme.Scheme.ObjectKinds(list.Items[i].DeepCopyObject())
+		gvks, _, err := scheme.Scheme.ObjectKinds(&list.Items[i])
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -133,7 +133,7 @@ func redactList(list *unstructured.UnstructuredList) error {
 		}
 		for _, gvk := range gvks {
 			// If this item is a Secret then we need to redact it.
-			if gvk.Kind == "Secret" {
+			if gvk.Kind == "Secret" && (gvk.Group == "Core" || gvk.Group == "") {
 				// Redact the Secret by overwriting its data.
 				list.Items[i].Object["data"] = map[string]interface{}{}
 				break

--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -121,27 +121,9 @@ func (g *DataGatherer) Fetch() (interface{}, error) {
 }
 
 func redactList(list *unstructured.UnstructuredList) error {
-	// Determine the kind of list.
-	gvks, unversioned, err := scheme.Scheme.ObjectKinds(list.DeepCopyObject())
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	redactList := false
-	if unversioned {
-		redactList = true
-	} else {
-		for _, gvk := range gvks {
-			// If this is SecretList or a generic list then it will need to be redacted.
-			if gvk.Kind == "SecretList" || gvk.Kind == "List" {
-				redactList = true
-				break
-			}
-		}
-	}
-	// Stop here if we don't need to redact this type of list.
-	if !redactList {
-		return nil
-	}
+	// In principal we could only redact the list if it's kind is SecretList or
+	// a generic mixed List, however the test suite does not set the list kind
+	// and it is safer to always check for Secrets.
 	// Iterate over the items in the list.
 	for i := range list.Items {
 		// Determine the kind of items in case this is a generic 'mixed' list.

--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -117,14 +117,15 @@ func (g *DataGatherer) Fetch() (interface{}, error) {
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
+		redact := false
 		for _, gvk := range gvks {
-			redact := false
 			if gvk.Kind == "Secret" {
 				redact = true
+				break
 			}
-			if redact {
-				list.Items[i].Object["data"] = map[string]interface{}{}
-			}
+		}
+		if redact {
+			list.Items[i].Object["data"] = map[string]interface{}{}
 		}
 	}
 	return list, nil

--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jetstack/preflight/pkg/datagatherer"
 	"github.com/pkg/errors"
@@ -109,6 +110,12 @@ func (g *DataGatherer) Fetch() (interface{}, error) {
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+	// Redact Secret data
+	if strings.ToLower(g.groupVersionResource.Resource) == "secret" {
+		for i := range list.Items {
+			list.Items[i].Object["data"] = map[string]interface{}{}
+		}
 	}
 	return list, nil
 }

--- a/pkg/datagatherer/k8s/generic_test.go
+++ b/pkg/datagatherer/k8s/generic_test.go
@@ -25,6 +25,12 @@ func getObject(version, kind, name, namespace string) *unstructured.Unstructured
 	}
 }
 
+func getSecret(name, namespace string, data map[string]interface{}) *unstructured.Unstructured {
+	object := getObject("v1", "Secret", name, namespace)
+	object.Object["data"] = data
+	return object
+}
+
 func asUnstructuredList(items ...*unstructured.Unstructured) *unstructured.UnstructuredList {
 	itemsNonPtr := make([]unstructured.Unstructured, len(items))
 	for i, u := range items {
@@ -84,6 +90,21 @@ func TestGenericGatherer_Fetch(t *testing.T) {
 			expected: asUnstructuredList(
 				getObject("foobar/v1", "Foo", "testfoo", "testns"),
 				getObject("foobar/v1", "Foo", "testfoo", "nottestns"),
+			),
+		},
+		"Secret resources should have data removed": {
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "Secret"},
+			objects: []runtime.Object{
+				getSecret("testsecret", "testns", map[string]interface{}{
+					"secretKey": "secretValue",
+				}),
+				getSecret("anothertestsecret", "differentns", map[string]interface{}{
+					"secretNumber": "12345",
+				}),
+			},
+			expected: asUnstructuredList(
+				getSecret("testsecret", "testns", map[string]interface{}{}),
+				getSecret("anothertestsecret", "differentns", map[string]interface{}{}),
 			),
 		},
 		// Note that we can't test use of fieldSelector to exclude namespaces

--- a/pkg/datagatherer/k8s/generic_test.go
+++ b/pkg/datagatherer/k8s/generic_test.go
@@ -93,7 +93,7 @@ func TestGenericGatherer_Fetch(t *testing.T) {
 			),
 		},
 		"Secret resources should have data removed": {
-			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "Secret"},
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
 			objects: []runtime.Object{
 				getSecret("testsecret", "testns", map[string]interface{}{
 					"secretKey": "secretValue",


### PR DESCRIPTION
This PR changes the Kubernetes data gatherer so that when Secret resources are gathered their data is removed.

Closes #129 