### PR TITLE
Support providing auth token in cli flag

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -20,6 +20,13 @@ func init() {
 		"agent-config-file",
 		"c",
 		"./agent.yaml",
-		"Config file location, default is `agent.yaml` in the current working directory",
+		"Config file location, default is `agent.yaml` in the current working directory.",
+	)
+	agentCmd.PersistentFlags().StringVarP(
+		&agent.AuthToken,
+		"auth-token",
+		"t",
+		"",
+		"Authorization token. If used, it will override the authorization token in the configuration file.",
 	)
 }


### PR DESCRIPTION
This is convenient in some cases.

For instance, now it is easier to inject an env. variable with `kubectl set env` and user it in as a flag.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>