### PR TITLE
Add agent config instead of old config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN make install
 FROM gcr.io/distroless/base:nonroot
 COPY --from=builder /go/bin/preflight /bin/preflight
 ADD ./preflight-packages /preflight-packages
-# load in an example preflight.yaml
-ADD ./examples/pods.preflight.yaml /etc/preflight/preflight.yaml
+# load in an example config file
+ADD ./agent.yaml /etc/preflight/agent.yaml
 ENTRYPOINT ["preflight"]
-CMD ["check", "--config-file", "/etc/preflight/preflight.yaml"]
+CMD ["agent", "-c", "/etc/preflight/agent.yaml"]


### PR DESCRIPTION
[Image builds are failing](https://prow.build-infra.jetstack.net/view/gcs/jetstack-logs/logs/post-preflight-release-canary/1240239917678727168) because we were trying to load the legacy config.

This changes the Dockerfile so we default to the agent command and we load the agent config.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>