### PR TITLE
Bind env variables to config flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -17,6 +19,12 @@ configuration checks using Open Policy Agent (OPA).
 Preflight checks are bundled into Packages`,
 }
 
+func init() {
+	for _, command := range rootCmd.Commands() {
+		setFlagsFromEnv("PREFLIGHT_", command.PersistentFlags())
+	}
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -24,4 +32,23 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+}
+
+func setFlagsFromEnv(prefix string, fs *pflag.FlagSet) {
+	set := map[string]bool{}
+	fs.Visit(func(f *pflag.Flag) {
+		set[f.Name] = true
+	})
+	fs.VisitAll(func(f *pflag.Flag) {
+		// ignore flags set from the commandline
+		if set[f.Name] {
+			return
+		}
+		// remove trailing _ to reduce common errors with the prefix, i.e. people setting it to MY_PROG_
+		cleanPrefix := strings.TrimSuffix(prefix, "_")
+		name := fmt.Sprintf("%s_%s", cleanPrefix, strings.Replace(strings.ToUpper(f.Name), "-", "_", -1))
+		if e, ok := os.LookupEnv(name); ok {
+			_ = f.Value.Set(e)
+		}
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/open-policy-agent/opa v0.16.0
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.5.0
 	github.com/yudai/gojsondiff v1.0.0
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect


### PR DESCRIPTION
This binds environment variables to cli flags which makes configuration easier for containers.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>