### PR TITLE
Fix some missing references to deprecated examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build-all-platforms:
 	cd $(ROOT_DIR) && \
 	mkdir -p ./bundles && \
 	tar --transform "s/assets\/packages/preflight-packages/" -cvf $@.tmp ./preflight-packages/ && \
-	tar --transform "s/examples\/pods.preflight.yaml/preflight.yaml/" -rvf $@.tmp examples/pods.preflight.yaml && \
+	tar --transform "s/deprecated-check-examples\/pods.preflight.yaml/preflight.yaml/" -rvf $@.tmp examples/pods.preflight.yaml && \
 	tar --transform "s/builds\/preflight-$(GOOS)-$(GOARCH)/preflight/" -rvf $@.tmp $< && \
 	gzip < $@.tmp > $@ && \
 	rm $@.tmp

--- a/docs/check.md
+++ b/docs/check.md
@@ -55,7 +55,7 @@ You can compile Preflight by running `make build`. It will create the binary in
 
 Create your `preflight.yaml` configuration file. There is full [configuration
 documentation](./docs/configuration.md) available, as well as several example
-files in [`./examples`](./examples).
+files in [`./deprecated-check-examples`](./deprecated-check-examples).
 
 ### Locally
 
@@ -67,13 +67,13 @@ preflight check
 ```
 
 You can try the Pods example
-[`./examples/pods.preflight.yaml`](./examples/pods.preflight.yaml)
+[`./deprecated-check-examples/pods.preflight.yaml`](./deprecated-check-examples/pods.preflight.yaml)
 without having to change a line,
 if your *kubeconfig* is located at `~/.kube/config` and
 is pointing to a working cluster.
 
 ```
-preflight check --config-file=./examples/pods.preflight.yaml
+preflight check --config-file=./deprecated-check-examples/pods.preflight.yaml
 ```
 
 You will see a CLI formatted report if everything goes well. Also, you will get
@@ -87,8 +87,8 @@ If you want to visualise the report in your browser, you can access the
 server.** **Everything happens in your browser.**
 
 You can give it a try without even running the tool, since we provide some
-report examples, [gke.json](./examples/reports/gke.json),
-and[pods.json](./examples/reports/pods.json), ready to be loaded into the
+report examples, [gke.json](./deprecated-check-examples/reports/gke.json),
+and[pods.json](./deprecated-check-examples/reports/pods.json), ready to be loaded into the
 [*Preflight Web UI*](https://preflight.jetstack.io/).
 
 ### In-Cluster
@@ -284,7 +284,8 @@ Configuration is provided to the Preflight application using a YAML file.
 This specifies what packages to use, how data gatherers are configured,
 and what outputs to produce.
 
-Several example configuration files can be found in [`examples`](./examples).
+Several example configuration files can be found in
+[`examples`](./deprecated-check-examples).
 
 ### Cluster Name
 


### PR DESCRIPTION
Follows fix in https://github.com/jetstack/preflight/pull/140

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>