### PR TITLE
Scrape only Included namespaces when set to allow more restricted RBAC

### DIFF
--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jetstack/preflight/pkg/datagatherer"
 	"github.com/pkg/errors"
@@ -22,6 +23,8 @@ type Config struct {
 	GroupVersionResource schema.GroupVersionResource
 	// ExcludeNamespaces is a list of namespaces to exclude.
 	ExcludeNamespaces []string `yaml:"exclude-namespaces"`
+	// IncludeNamespaces is a list of namespaces to include.
+	IncludeNamespaces []string `yaml:"include-namespaces"`
 }
 
 // UnmarshalYAML unmarshals the Config resolving GroupVersionResource.
@@ -51,8 +54,17 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // validate validates the configuration.
 func (c *Config) validate() error {
+	var errors []string
+	if len(c.ExcludeNamespaces) > 0 && len(c.IncludeNamespaces) > 0 {
+		errors = append(errors, "cannot set excluded an included namespaces")
+	}
+
 	if c.GroupVersionResource.Resource == "" {
-		return fmt.Errorf("invalid configuration: GroupVersionResource.Resource cannot be empty")
+		errors = append(errors, "invalid configuration: GroupVersionResource.Resource cannot be empty")
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf(strings.Join(errors, ", "))
 	}
 
 	return nil

--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -56,7 +56,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (c *Config) validate() error {
 	var errors []string
 	if len(c.ExcludeNamespaces) > 0 && len(c.IncludeNamespaces) > 0 {
-		errors = append(errors, "cannot set excluded an included namespaces")
+		errors = append(errors, "cannot set excluded and included namespaces")
 	}
 
 	if c.GroupVersionResource.Resource == "" {

--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -73,12 +73,16 @@ func (c *Config) validate() error {
 // NewDataGatherer constructs a new instance of the generic K8s data-gatherer for the provided
 // GroupVersionResource.
 func (c *Config) NewDataGatherer(ctx context.Context) (datagatherer.DataGatherer, error) {
-	if err := c.validate(); err != nil {
+	cl, err := NewDynamicClient(c.KubeConfigPath)
+	if err != nil {
 		return nil, err
 	}
 
-	cl, err := NewDynamicClient(c.KubeConfigPath)
-	if err != nil {
+	return c.newDataGathererWithClient(cl)
+}
+
+func (c *Config) newDataGathererWithClient(cl dynamic.Interface) (datagatherer.DataGatherer, error) {
+	if err := c.validate(); err != nil {
 		return nil, err
 	}
 
@@ -86,7 +90,7 @@ func (c *Config) NewDataGatherer(ctx context.Context) (datagatherer.DataGatherer
 		cl:                   cl,
 		groupVersionResource: c.GroupVersionResource,
 		fieldSelector:        generateFieldSelector(c.ExcludeNamespaces),
-		namespaces:           []string{},
+		namespaces:           c.IncludeNamespaces,
 	}, nil
 }
 

--- a/pkg/datagatherer/k8s/generic.go
+++ b/pkg/datagatherer/k8s/generic.go
@@ -121,7 +121,13 @@ func (g *DataGatherer) Fetch() (interface{}, error) {
 
 	var list unstructured.UnstructuredList
 
-	for _, namespace := range g.namespaces {
+	fetchNamespaces := g.namespaces
+	if len(fetchNamespaces) == 0 {
+		// then they must have been looking for all namespaces
+		fetchNamespaces = []string{""}
+	}
+
+	for _, namespace := range fetchNamespaces {
 		resourceInterface := namespaceResourceInterface(g.cl.Resource(g.groupVersionResource), namespace)
 		namespaceList, err := resourceInterface.List(metav1.ListOptions{
 			FieldSelector: g.fieldSelector,

--- a/pkg/datagatherer/k8s/generic_test.go
+++ b/pkg/datagatherer/k8s/generic_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -206,11 +207,18 @@ func TestConfigValidate(t *testing.T) {
 			},
 			ExpectedError: "invalid configuration: GroupVersionResource.Resource cannot be empty",
 		},
+		{
+			Config: Config{
+				IncludeNamespaces: []string{"a"},
+				ExcludeNamespaces: []string{"b"},
+			},
+			ExpectedError: "cannot set excluded an included namespaces",
+		},
 	}
 
 	for _, test := range tests {
 		err := test.Config.validate()
-		if err.Error() != test.ExpectedError {
+		if !strings.Contains(err.Error(), test.ExpectedError) {
 			t.Errorf("expected %s, got %s", test.ExpectedError, err.Error())
 		}
 	}

--- a/pkg/datagatherer/k8s/generic_test.go
+++ b/pkg/datagatherer/k8s/generic_test.go
@@ -252,7 +252,7 @@ func TestConfigValidate(t *testing.T) {
 				IncludeNamespaces: []string{"a"},
 				ExcludeNamespaces: []string{"b"},
 			},
-			ExpectedError: "cannot set excluded an included namespaces",
+			ExpectedError: "cannot set excluded and included namespaces",
 		},
 	}
 

--- a/pkg/datagatherer/k8s/generic_test.go
+++ b/pkg/datagatherer/k8s/generic_test.go
@@ -191,6 +191,31 @@ exclude-namespaces:
 	}
 }
 
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		Config        Config
+		ExpectedError string
+	}{
+		{
+			Config: Config{
+				GroupVersionResource: schema.GroupVersionResource{
+					Group:    "",
+					Version:  "",
+					Resource: "",
+				},
+			},
+			ExpectedError: "invalid configuration: GroupVersionResource.Resource cannot be empty",
+		},
+	}
+
+	for _, test := range tests {
+		err := test.Config.validate()
+		if err.Error() != test.ExpectedError {
+			t.Errorf("expected %s, got %s", test.ExpectedError, err.Error())
+		}
+	}
+}
+
 func TestGenerateFieldSelector(t *testing.T) {
 	tests := []struct {
 		ExcludeNamespaces     []string

--- a/pkg/datagatherer/k8s/generic_test.go
+++ b/pkg/datagatherer/k8s/generic_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -133,7 +134,7 @@ func TestGenericGatherer_Fetch(t *testing.T) {
 			g := DataGatherer{
 				cl:                   cl,
 				groupVersionResource: test.gvr,
-				namespace:            test.namespace,
+				namespaces:           []string{test.namespace},
 			}
 
 			res, err := g.Fetch()
@@ -144,6 +145,9 @@ func TestGenericGatherer_Fetch(t *testing.T) {
 				t.Errorf("expected to get an error but didn't get one")
 			}
 			if !reflect.DeepEqual(res, test.expected) {
+				fmt.Printf("%+v\n", res)
+				fmt.Printf("%+v\n", test.expected)
+				fmt.Printf("---\n")
 				t.Errorf("unexpected difference: %v", diff.ObjectDiff(res, test.expected))
 			}
 		})


### PR DESCRIPTION
This implements https://github.com/jetstack/preflight/issues/155

Turns our that --field-selector in the API does not support set operations like label selectors :cry: I instead make a request for each namespace.