### PR TITLE
Fix bug with new preflight client and basic auth

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -44,6 +44,13 @@ func Run(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to parse config file: %s", err)
 	}
 
+	// AuthToken flag takes preference over token in configuration file.
+	if AuthToken == "" {
+		AuthToken = config.Token
+	} else {
+		log.Printf("Using authorization token from flag.")
+	}
+
 	if config.Token != "" {
 		config.Token = "(redacted)"
 	}
@@ -84,13 +91,6 @@ func Run(cmd *cobra.Command, args []string) {
 			log.Fatalf("Error creating preflight client: %+v", err)
 		}
 	} else {
-		// AuthToken flag takes preference over token in configuration file.
-		if AuthToken == "" {
-			AuthToken = config.Token
-		} else {
-			log.Printf("Using authorization token from flag.")
-		}
-
 		if AuthToken == "" {
 			log.Fatalf("Missing authorization token. Cannot continue.")
 		}


### PR DESCRIPTION
We introduced a regression in #159 as we were misconfiguring the preflight client with `"(redacted)"` instead of the actual token.

This contains the fix.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>