### PR TITLE
Make agent support new endpoint for gathering data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,12 @@ GO_INSTALL:=go install -ldflags '$(LDFLAGS)'
 
 export GO111MODULE=on
 
-.PHONY: build
-
 clean:
 	cd $(ROOT_DIR) && rm -rf ./builds ./bundles
 
 # Golang cli
 
+.PHONY: build
 build:
 	cd $(ROOT_DIR) && $(GO_BUILD) -o builds/preflight .
 
@@ -48,6 +47,7 @@ vet:
 lint: vet
 	cd $(ROOT_DIR) && golint
 
+.PHONY: ./builds/preflight-$(GOOS)-$(GOARCH)
 ./builds/preflight-$(GOOS)-$(GOARCH):
 	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) -o ./builds/preflight-$(GOOS)-$(GOARCH) .
 

--- a/api/agent.go
+++ b/api/agent.go
@@ -1,0 +1,6 @@
+package api
+
+// AgentMetadata is metadata about the agent.
+type AgentMetadata struct {
+	Version string `json:"version"`
+}

--- a/api/datareading.go
+++ b/api/datareading.go
@@ -1,7 +1,16 @@
 package api
 
+// DataReadingsPost is the payload in the upload request.
+type DataReadingsPost struct {
+	AgentMetadata *AgentMetadata `json:"agent_metadata"`
+	DataReadings  []*DataReading `json:"data_readings"`
+}
+
 // DataReading is the output of a DataGatherer.
 type DataReading struct {
+	// ClusterID is optional as it can be infered from the agent
+	// token when using basic authentication.
+	ClusterID    string      `json:"cluster_id,omitempty"`
 	DataGatherer string      `json:"data-gatherer"`
 	Timestamp    Time        `json:"timestamp"`
 	Data         interface{} `json:"data"`

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Post performs a post request.
+func (c *PreflightClient) Post(path string, body io.Reader) (*http.Response, error) {
+	var bearer string
+	if !c.usingOAuth2() {
+		bearer = c.basicAuthToken
+	} else {
+		token, err := c.getValidAccessToken()
+		if err != nil {
+			return nil, err
+		}
+		bearer = token.bearer
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.fullURL(path), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if len(bearer) > 0 {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearer))
+	}
+
+	return http.DefaultClient.Do(req)
+}
+
+func (c *PreflightClient) fullURL(path string) string {
+	base := c.baseURL
+	for strings.HasSuffix(base, "/") {
+		base = strings.TrimSuffix(base, "/")
+	}
+	for strings.HasPrefix(path, "/") {
+		path = strings.TrimPrefix(path, "/")
+	}
+	return fmt.Sprintf("%s/%s", base, path)
+}


### PR DESCRIPTION
This adds support for the new form of the endpoint that gathers data.

It introduces significant changes in the configuration, but everything should be backward compatible.

These changes are:

- The `Schedule` field is not optional, as we are using the period flag at the moment.
- The `Token` string is also optional, as it should not be specified when using OAuth2.
- The `Endpoint` is being deprecated, as in the future you won't configure the endpoint for uploading data, just preflight server. At the moment it is still being used if specified, but ignored and defaulting to `/api/v1/datareadings` otherwise.
- Added a new `Server` property that points to the Preflight server. Defaults to `https://preflight.jetstack.io` if not specified.
- Added `OrganizationID` which will be used with the new endpoint.
- Added `ClusterID`. To be left empty if using agent tokens (as they already point to a cluster).


Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>