### PR TITLE
Check post data error

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -178,6 +178,9 @@ func gatherAndPostData(ctx context.Context) {
 			path = "/api/v1/datareadings"
 		}
 		res, err := preflightClient.Post(path, bytes.NewBuffer(data))
+		if err != nil {
+			log.Fatalf("Failed to post data: %+v", err)
+		}
 		if code := res.StatusCode; code < 200 || code >= 300 {
 			errorContent := ""
 			body, _ := ioutil.ReadAll(res.Body)


### PR DESCRIPTION
If the server is not running (e.g. localhost) then we get a stack trace
without this. We should check the error.

Eventually, we can implement a more graceful retry policy.

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>