### PR TITLE
Implementation of k8s-discovery datagatherer

### DIFF
--- a/docs/datagatherers/k8s-discovery.md
+++ b/docs/datagatherers/k8s-discovery.md
@@ -1,0 +1,22 @@
+# k8s-discovery
+
+This datagatherer uses the [DiscoveryClient](https://godoc.org/k8s.io/client-go/discovery#DiscoveryClient)
+to get API server version information.
+
+Include the following in your agent config:
+
+```
+data-gatherers:
+- kind: "k8s-discovery"
+  name: "k8s-discovery"
+```
+
+or specify a kubeconfig file:
+
+```
+data-gatherers:
+- kind: "k8s-discovery"
+  name: "k8s-discovery"
+  config:
+    kubeconfig: other_kube_config_path
+```

--- a/docs/datagatherers/k8s-dynamic.md
+++ b/docs/datagatherers/k8s-dynamic.md
@@ -1,7 +1,7 @@
-# Kubernetes (k8s) Data Gatherer
+# Kubernetes Data Gatherer
 
-The Kubernetes data gatherer collects information about resources stored in
-the Kubernetes API.
+The Kubernetes dynamic data gatherer collects information about resources stored
+in the Kubernetes API.
 
 ## Data
 
@@ -28,16 +28,25 @@ below:
 ```yaml
 data-gatherers:
 # basic usage
-- kind: "k8s/pods.v1"
-  name: "pods"
+- kind: "k8s-dynamic"
+  name: "k8s/pods"
+  config:
+    resource-type:
+      resource: pods
+      version: v1
 
 # CRD usage
-- kind: "k8s/certificates.v1alpha2.cert-manager.io"
-  name: "certificates"
+- kind: "k8s-dynamic"
+  name: "k8s/certificates.v1alpha2.cert-manager.io"
+  config:
+    resource-type:
+      group: cert-manager.io
+      version: v1alpha2
+      resource: certificates
 
 # you might event want to gather resources from another cluster
-- kind: "k8s/pods.v1"
-  name: "pods-cluster-2"
+- kind: "k8s-dynamic"
+  name: "k8s/pods"
   config:
     kubeconfig: other_kube_config_path
 ```

--- a/examples/cert-manager-agent.yaml
+++ b/examples/cert-manager-agent.yaml
@@ -5,27 +5,27 @@ endpoint:
   host: "preflight.jetstack.io"
   path: "/api/v1/datareadings"
 data-gatherers:
-- kind: "k8s"
+- kind: "k8s-dynamic"
   name: "k8s/secrets.v1"
   config:
     resource-type:
       version: v1
       resource: secrets
-- kind: "k8s"
+- kind: "k8s-dynamic"
   name: "k8s/certificates.v1alpha2.cert-manager.io"
   config:
     resource-type:
       group: cert-manager.io
       version: v1alpha2
       resource: certificates
-- kind: "k8s"
+- kind: "k8s-dynamic"
   name: "k8s/ingresses.v1beta1.networking.k8s.io"
   config:
     resource-type:
       group: networking.k8s.io
       version: v1beta1
       resource: ingresses
-- kind: "k8s"
+- kind: "k8s-dynamic"
   name: "k8s/certificaterequests.v1alpha2.cert-manager.io"
   config:
     resource-type:

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -87,7 +87,11 @@ func (dg *dataGatherer) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case "aks":
 		cfg = &aks.Config{}
 	case "k8s":
-		cfg = &k8s.Config{}
+		cfg = &k8s.ConfigDynamic{}
+	case "k8s-dynamic":
+		cfg = &k8s.ConfigDynamic{}
+	case "k8s-discovery":
+		cfg = &k8s.ConfigDiscovery{}
 	case "local":
 		cfg = &local.Config{}
 	// dummy dataGatherer is just used for testing

--- a/pkg/datagatherer/k8s/client.go
+++ b/pkg/datagatherer/k8s/client.go
@@ -3,6 +3,7 @@ package k8s
 
 import (
 	"github.com/pkg/errors"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -21,6 +22,25 @@ func NewDynamicClient(kubeconfigPath string) (dynamic.Interface, error) {
 		return nil, errors.WithStack(err)
 	}
 	return cl, nil
+}
+
+// NewDiscoveryClient creates a new 'discovery' client using the provided
+// kubeconfig.  If kubeconfigPath is not set/empty, it will attempt to load
+// configuration using the default loading rules.
+func NewDiscoveryClient(kubeconfigPath string) (discovery.DiscoveryClient, error) {
+	var discoveryClient *discovery.DiscoveryClient
+
+	cfg, err := loadRESTConfig(kubeconfigPath)
+	if err != nil {
+		return *discoveryClient, errors.WithStack(err)
+	}
+
+	discoveryClient, err = discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return *discoveryClient, errors.WithStack(err)
+	}
+
+	return *discoveryClient, nil
 }
 
 func loadRESTConfig(path string) (*rest.Config, error) {

--- a/pkg/datagatherer/k8s/client_test.go
+++ b/pkg/datagatherer/k8s/client_test.go
@@ -34,6 +34,26 @@ func TestNewDynamicClient_InferredKubeconfig(t *testing.T) {
 	}
 }
 
+func TestNewDiscoveryClient_ExplicitKubeconfig(t *testing.T) {
+	kc := createValidTestConfig()
+	path := writeConfigToFile(t, kc)
+	_, err := NewDiscoveryClient(path)
+	if err != nil {
+		t.Error("failed to create client: ", err)
+	}
+}
+
+func TestNewDiscoveryClient_InferredKubeconfig(t *testing.T) {
+	kc := createValidTestConfig()
+	path := writeConfigToFile(t, kc)
+	cleanupFn := temporarilySetEnv("KUBECONFIG", path)
+	defer cleanupFn()
+	_, err := NewDiscoveryClient("")
+	if err != nil {
+		t.Error("failed to create client: ", err)
+	}
+}
+
 func writeConfigToFile(t *testing.T, cfg clientcmdapi.Config) string {
 	f, err := ioutil.TempFile("", "testcase-*")
 	if err != nil {

--- a/pkg/datagatherer/k8s/discovery.go
+++ b/pkg/datagatherer/k8s/discovery.go
@@ -54,6 +54,7 @@ func (g *DataGathererDiscovery) Fetch() (interface{}, error) {
 	}
 
 	response := map[string]interface{}{
+		// data has type Info: https://godoc.org/k8s.io/apimachinery/pkg/version#Info
 		"server_version": data,
 	}
 

--- a/pkg/datagatherer/k8s/discovery.go
+++ b/pkg/datagatherer/k8s/discovery.go
@@ -1,0 +1,61 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jetstack/preflight/pkg/datagatherer"
+	"k8s.io/client-go/discovery"
+)
+
+// ConfigDiscovery contains the configuration for the k8s-discovery data-gatherer
+type ConfigDiscovery struct {
+	// KubeConfigPath is the path to the kubeconfig file. If empty, will assume it runs in-cluster.
+	KubeConfigPath string `yaml:"kubeconfig"`
+}
+
+// UnmarshalYAML unmarshals the Config resolving GroupVersionResource.
+func (c *ConfigDiscovery) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	aux := struct {
+		KubeConfigPath string `yaml:"kubeconfig"`
+	}{}
+	err := unmarshal(&aux)
+	if err != nil {
+		return err
+	}
+
+	c.KubeConfigPath = aux.KubeConfigPath
+
+	return nil
+}
+
+// NewDataGatherer constructs a new instance of the generic K8s data-gatherer for the provided
+// GroupVersionResource.
+func (c *ConfigDiscovery) NewDataGatherer(ctx context.Context) (datagatherer.DataGatherer, error) {
+	cl, err := NewDiscoveryClient(c.KubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DataGathererDiscovery{cl: cl}, nil
+}
+
+// DataGathererDiscovery stores the config for a k8s-discovery datagatherer
+type DataGathererDiscovery struct {
+	// The 'discovery' client used for fetching data.
+	cl discovery.DiscoveryClient
+}
+
+// Fetch will fetch discovery data from the apiserver, or return an error
+func (g *DataGathererDiscovery) Fetch() (interface{}, error) {
+	data, err := g.cl.ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server version: %v", err)
+	}
+
+	response := map[string]interface{}{
+		"server_version": data,
+	}
+
+	return response, nil
+}

--- a/pkg/datagatherer/k8s/dynamic_test.go
+++ b/pkg/datagatherer/k8s/dynamic_test.go
@@ -62,7 +62,7 @@ func asUnstructuredList(items ...*unstructured.Unstructured) *unstructured.Unstr
 }
 
 func TestNewDataGathererWithClient(t *testing.T) {
-	config := Config{
+	config := ConfigDynamic{
 		IncludeNamespaces:    []string{"a"},
 		GroupVersionResource: schema.GroupVersionResource{Group: "foobar", Version: "v1", Resource: "foos"},
 	}
@@ -73,7 +73,7 @@ func TestNewDataGathererWithClient(t *testing.T) {
 		t.Errorf("expected no error but got: %v", err)
 	}
 
-	expected := &DataGatherer{
+	expected := &DataGathererDynamic{
 		cl:                   cl,
 		groupVersionResource: config.GroupVersionResource,
 		// it's important that the namespaces are set as the IncludeNamespaces
@@ -168,7 +168,7 @@ func TestGenericGatherer_Fetch(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			cl := fake.NewSimpleDynamicClient(emptyScheme, test.objects...)
-			g := DataGatherer{
+			g := DataGathererDynamic{
 				cl:                   cl,
 				groupVersionResource: test.gvr,
 				// if empty, namespaces will default to []string{""} during
@@ -190,7 +190,7 @@ func TestGenericGatherer_Fetch(t *testing.T) {
 	}
 }
 
-func TestUnmarshalConfig(t *testing.T) {
+func TestUnmarshalGenericConfig(t *testing.T) {
 	textCfg := `
 kubeconfig: "/home/someone/.kube/config"
 resource-type:
@@ -213,7 +213,7 @@ exclude-namespaces:
 		"my-namespace",
 	}
 
-	cfg := Config{}
+	cfg := ConfigDynamic{}
 	err := yaml.Unmarshal([]byte(textCfg), &cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
@@ -232,13 +232,13 @@ exclude-namespaces:
 	}
 }
 
-func TestConfigValidate(t *testing.T) {
+func TestConfigDynamicValidate(t *testing.T) {
 	tests := []struct {
-		Config        Config
+		Config        ConfigDynamic
 		ExpectedError string
 	}{
 		{
-			Config: Config{
+			Config: ConfigDynamic{
 				GroupVersionResource: schema.GroupVersionResource{
 					Group:    "",
 					Version:  "",
@@ -248,7 +248,7 @@ func TestConfigValidate(t *testing.T) {
 			ExpectedError: "invalid configuration: GroupVersionResource.Resource cannot be empty",
 		},
 		{
-			Config: Config{
+			Config: ConfigDynamic{
 				IncludeNamespaces: []string{"a"},
 				ExcludeNamespaces: []string{"b"},
 			},


### PR DESCRIPTION
This makes use of the discovery client in client-go to get the server
version information. We need this to use in upcoming packages.

https://godoc.org/k8s.io/client-go/discovery

Sadly, the fake discovery client doesn't seem to work in the same way as
the dynamic one and I've not spent the time to write tests around it.
However, it's operation is much simpler. Open to suggestions on how to
test this in the same way as the dynamic client.

This PR also updates all docs and renames the k8s datagatherer to
k8s-dynamic in a backwards compatible manner.

(Internal Issue: https://github.com/jetstack/preflight-platform/issues/350)