### PR TITLE
Refresh config, data per run (and allow partial data posting)

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -35,6 +35,13 @@ var CredentialsPath string
 func Run(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 
+	for {
+		gatherAndPostData(ctx)
+		time.Sleep(time.Duration(Period) * time.Second)
+	}
+}
+
+func gatherAndPostData(ctx context.Context) {
 	file, err := os.Open(ConfigFilePath)
 	if err != nil {
 		log.Fatalf("Failed to load config file for agent from: %s", ConfigFilePath)
@@ -159,37 +166,35 @@ func Run(cmd *cobra.Command, args []string) {
 		)
 	}
 
-	for {
-		log.Println("Running Agent...")
-		log.Println("Posting data to ", baseURL)
-		if config.OrganizationID == "" {
-			data, err := json.Marshal(readings)
-			if err != nil {
-				log.Fatalf("Cannot marshal readings: %+v", err)
-			}
-			path := config.Endpoint.Path
-			if path == "" {
-				path = "/api/v1/datareadings"
-			}
-			res, err := preflightClient.Post(path, bytes.NewBuffer(data))
-			if code := res.StatusCode; code < 200 || code >= 300 {
-				errorContent := ""
-				body, _ := ioutil.ReadAll(res.Body)
-				if err == nil {
-					errorContent = string(body)
-				}
-				defer res.Body.Close()
-
-				log.Fatalf("Received response with status code %d. Body: %s", code, errorContent)
-			}
-		} else {
-			err = preflightClient.PostDataReadings(config.OrganizationID, readings)
-			// TODO: handle errors gracefully: e.g. handle retries when it is possible
-			if err != nil {
-				log.Fatalf("Post to server failed: %+v", err)
-			}
+	log.Println("Running Agent...")
+	log.Println("Posting data to ", baseURL)
+	if config.OrganizationID == "" {
+		data, err := json.Marshal(readings)
+		if err != nil {
+			log.Fatalf("Cannot marshal readings: %+v", err)
 		}
-		log.Println("Data sent successfully.")
-		time.Sleep(time.Duration(Period) * time.Second)
+		path := config.Endpoint.Path
+		if path == "" {
+			path = "/api/v1/datareadings"
+		}
+		res, err := preflightClient.Post(path, bytes.NewBuffer(data))
+		if code := res.StatusCode; code < 200 || code >= 300 {
+			errorContent := ""
+			body, _ := ioutil.ReadAll(res.Body)
+			if err == nil {
+				errorContent = string(body)
+			}
+			defer res.Body.Close()
+
+			log.Fatalf("Received response with status code %d. Body: %s", code, errorContent)
+		}
+	} else {
+		err = preflightClient.PostDataReadings(config.OrganizationID, readings)
+		// TODO: handle errors gracefully: e.g. handle retries when it is possible
+		if err != nil {
+			log.Fatalf("Post to server failed: %+v", err)
+		}
 	}
+
+	log.Println("Data sent successfully.")
 }


### PR DESCRIPTION
We have plans to enable more dgs by default. If these fail, the agent should still attempt to send partial data.

Agent should also refresh data per run and config too to load in any changes in its work.