### PR TITLE
Add agent info command

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/jetstack/preflight/pkg/agent"
 	"github.com/spf13/cobra"
 )
@@ -13,8 +15,20 @@ var agentCmd = &cobra.Command{
 	Run: agent.Run,
 }
 
+var agentInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "print several internal parameters of the agent",
+	Long:  `Print several internal parameters of the agent, as the built-in OAuth2 client ID.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		printVersion(true)
+		fmt.Println()
+		printOAuth2Config()
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(agentCmd)
+	agentCmd.AddCommand(agentInfoCmd)
 	agentCmd.PersistentFlags().StringVarP(
 		&agent.ConfigFilePath,
 		"agent-config-file",
@@ -41,6 +55,6 @@ func init() {
 		"credentials-file",
 		"k",
 		"",
-		"(Experimental) Location of the credentials file. For OAuth2 based authentication.",
+		"Location of the credentials file. For OAuth2 based authentication.",
 	)
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/jetstack/preflight/pkg/client"
+	"github.com/jetstack/preflight/pkg/version"
+)
+
+func printVersion(verbose bool) {
+	fmt.Println("Preflight version: ", version.PreflightVersion, version.Platform)
+	if verbose {
+		fmt.Println("  Commit: ", version.Commit)
+		fmt.Println("  Built:  ", version.BuildDate)
+		fmt.Println("  Go:     ", version.GoVersion)
+	}
+}
+
+func printOAuth2Config() {
+	fmt.Println("OAuth2: ")
+	fmt.Println("  ClientID:         ", client.ClientID)
+	fmt.Println("  AuthServerDomain: ", client.AuthServerDomain)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,10 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/jetstack/preflight/pkg/version"
-
 	"github.com/spf13/cobra"
 )
 
@@ -16,13 +12,7 @@ var versionCmd = &cobra.Command{
 	Long: `Display preflight version.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Preflight version: ", version.PreflightVersion, version.Platform)
-		if verbose {
-			fmt.Println()
-			fmt.Println("Commit: ", version.Commit)
-			fmt.Println("Built: ", version.BuildDate)
-			fmt.Println("Go: ", version.GoVersion)
-		}
+		printVersion(verbose)
 	},
 }
 


### PR DESCRIPTION
Add a `preflight agent info` command that prints some useful debugging information.

Remove the "Experimental" tag for the credentials file, as it is fully supported now.