### PR TITLE
Catch missing OAuth2 credentials

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -72,6 +72,10 @@ func New(agentMetadata *api.AgentMetadata, credentials *Credentials, baseURL str
 }
 
 func (c *PreflightClient) usingOAuth2() bool {
+	if c.credentials == nil {
+		return false
+	}
+
 	return c.credentials.UserID != ""
 }
 


### PR DESCRIPTION
I ran into this will the following agent yaml

<details><summary>expand</summary>
<p>




```yaml
schedule: "* * * * *"
token: [redacted]
endpoint:
  protocol: https
  host: preflight.jetstack.io
  path: /api/v1/datareadings
data-gatherers:
- kind: "k8s-dynamic"
  name: "k8s/pods"
  config:
    resource-type:
      resource: pods
      version: v1
# gather services for pod readiness probe rules
- kind: "k8s-dynamic"
  name: "k8s/services.v1"
  config:
    resource-type:
      resource: services
      version: v1
# gather resources for cert-manager package
- kind: "k8s-dynamic"
  name: "k8s/secrets.v1"
  config:
    resource-type:
      version: v1
      resource: secrets
- kind: "k8s-dynamic"
  name: "k8s/certificates.v1alpha2.cert-manager.io"
  config:
    resource-type:
      group: cert-manager.io
      version: v1alpha2
      resource: certificates
- kind: "k8s-dynamic"
  name: "k8s/ingresses.v1beta1.networking.k8s.io"
  config:
    resource-type:
      group: networking.k8s.io
      version: v1beta1
      resource: ingresses
- kind: "k8s-dynamic"
  name: "k8s/certificaterequests.v1alpha2.cert-manager.io"
  config:
    resource-type:
      group: cert-manager.io
      version: v1alpha2
      resource: certificaterequests
# gather k8s apiserver version information
- kind: "k8s-discovery"
  name: "k8s-discovery"
# gather deprecated resources
- kind: "k8s-dynamic"
  name: "k8s/networkpolicies.v1beta1.extensions"
  config:
    resource-type:
      group: extensions
      version: v1beta1
      resource: networkpolicies
- kind: "k8s-dynamic"
  name: "k8s/podsecuritypolicies.v1beta1.extensions"
  config:
    resource-type:
      group: extensions
      version: v1beta1
      resource: podsecuritypolicies
- kind: "k8s-dynamic"
  name: "k8s/daemonsets.v1beta1.extensions"
  config:
    resource-type:
      group: extensions
      version: v1beta1
      resource: daemonsets
- kind: "k8s-dynamic"
  name: "k8s/daemonsets.v1beta2.apps"
  config:
    resource-type:
      group: apps
      version: v1beta2
      resource: daemonsets
- kind: "k8s-dynamic"
  name: "k8s/deployments.v1beta1.extensions"
  config:
    resource-type:
      group: extensions
      version: v1beta1
      resource: deployments
- kind: "k8s-dynamic"
  name: "k8s/deployments.v1beta1.apps"
  config:
    resource-type:
      group: apps
      version: v1beta1
      resource: deployments
- kind: "k8s-dynamic"
  name: "k8s/deployments.v1beta2.apps"
  config:
    resource-type:
      group: apps
      version: v1beta2
      resource: deployments
- kind: "k8s-dynamic"
  name: "k8s/statefulsets.v1beta1.apps"
  config:
    resource-type:
      group: apps
      version: v1beta1
      resource: statefulsets
- kind: "k8s-dynamic"
  name: "k8s/statefulsets.v1beta2.apps"
  config:
    resource-type:
      group: apps
      version: v1beta2
      resource: statefulsets
- kind: "k8s-dynamic"
  name: "k8s/replicasets.v1beta1.extensions"
  config:
    resource-type:
      group: extensions
      version: v1beta1
      resource: replicasets
- kind: "k8s-dynamic"
  name: "k8s/replicasets.v1beta1.apps"
  config:
    resource-type:
      group: apps
      version: v1beta1
      resource: replicasets
- kind: "k8s-dynamic"
  name: "k8s/replicasets.v1beta2.apps"
  config:
    resource-type:
      group: apps
      version: v1beta2
      resource: replicasets
- kind: "k8s-dynamic"
  name: "k8s/ingresses.v1beta1.extensions"
  config:
    resource-type:
      group: extensions
      version: v1beta1
      resource: ingresses
```

</p>
</details>
