### PR TITLE
Log version to make debugging easier

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -42,6 +42,7 @@ func Run(cmd *cobra.Command, args []string) {
 }
 
 func gatherAndPostData(ctx context.Context) {
+	log.Printf("Preflight agent version: %s (%s)", version.PreflightVersion, version.Commit)
 	file, err := os.Open(ConfigFilePath)
 	if err != nil {
 		log.Fatalf("Failed to load config file for agent from: %s", ConfigFilePath)


### PR DESCRIPTION
Logging the version at the beginning would make it easier debugging of user issues when they paste the logs.