### PR TITLE
Set included namespaces as loaded from config

### DIFF
--- a/agent.yaml
+++ b/agent.yaml
@@ -1,5 +1,5 @@
 schedule: "* * * *"
-token: eyJjbHVzdGVyIjoibXkgY2x1c3RlciIsInRva2VuIjoidG9rZW4yYiJ9
+token: ewogICJjbHVzdGVyIjogIm15IGNsdXN0ZXIiLAogICJ0b2tlbiI6ICJleGFtcGxlIgp9Cg==
 endpoint:
   protocol: http
   host: "localhost:8080"

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -37,6 +37,7 @@ func (c *ConfigDynamic) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			Resource string `yaml:"resource"`
 		} `yaml:"resource-type"`
 		ExcludeNamespaces []string `yaml:"exclude-namespaces"`
+		IncludeNamespaces []string `yaml:"include-namespaces"`
 	}{}
 	err := unmarshal(&aux)
 	if err != nil {
@@ -48,6 +49,7 @@ func (c *ConfigDynamic) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	c.GroupVersionResource.Version = aux.ResourceType.Version
 	c.GroupVersionResource.Resource = aux.ResourceType.Resource
 	c.ExcludeNamespaces = aux.ExcludeNamespaces
+	c.IncludeNamespaces = aux.IncludeNamespaces
 
 	return nil
 }

--- a/pkg/datagatherer/k8s/dynamic_test.go
+++ b/pkg/datagatherer/k8s/dynamic_test.go
@@ -86,7 +86,7 @@ func TestNewDataGathererWithClient(t *testing.T) {
 	}
 }
 
-func TestGenericGatherer_Fetch(t *testing.T) {
+func TestDynamicGatherer_Fetch(t *testing.T) {
 	emptyScheme := runtime.NewScheme()
 	tests := map[string]struct {
 		gvr        schema.GroupVersionResource
@@ -190,7 +190,7 @@ func TestGenericGatherer_Fetch(t *testing.T) {
 	}
 }
 
-func TestUnmarshalGenericConfig(t *testing.T) {
+func TestUnmarshalDynamicConfig(t *testing.T) {
 	textCfg := `
 kubeconfig: "/home/someone/.kube/config"
 resource-type:
@@ -200,6 +200,11 @@ resource-type:
 exclude-namespaces:
 - kube-system
 - my-namespace
+# this config is invalid, but the validation is tested elsewhere
+# include-namespaces is here just to ensure that they are loaded
+# from the config file
+include-namespaces:
+- default
 `
 
 	expectedGVR := schema.GroupVersionResource{
@@ -212,6 +217,8 @@ exclude-namespaces:
 		"kube-system",
 		"my-namespace",
 	}
+
+	expectedIncludeNamespaces := []string{"default"}
 
 	cfg := ConfigDynamic{}
 	err := yaml.Unmarshal([]byte(textCfg), &cfg)
@@ -229,6 +236,9 @@ exclude-namespaces:
 
 	if got, want := cfg.ExcludeNamespaces, expectedExcludeNamespaces; !reflect.DeepEqual(got, want) {
 		t.Errorf("ExcludeNamespaces does not match: got=%+v want=%+v", got, want)
+	}
+	if got, want := cfg.IncludeNamespaces, expectedIncludeNamespaces; !reflect.DeepEqual(got, want) {
+		t.Errorf("IncludeNamespaces does not match: got=%+v want=%+v", got, want)
 	}
 }
 


### PR DESCRIPTION
This feature was implemented but was not connected to the config file -
oops, my bad!

This also updated the default token to match the one used in the backend for the dummy org.

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>