### PR TITLE
Adds write-to-file flag to store data locally

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -64,5 +64,12 @@ func init() {
 		false,
 		"Runs agent a single time if true, or continously if false",
 	)
+	agentCmd.PersistentFlags().StringVarP(
+		&agent.DataFilePath,
+		"write-to-file",
+		"",
+		"",
+		"Data file path, if used will write data to a local file instead of posting",
+	)
 
 }

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -65,11 +65,11 @@ func init() {
 		"Runs agent a single time if true, or continously if false",
 	)
 	agentCmd.PersistentFlags().StringVarP(
-		&agent.DataFilePath,
-		"write-to-file",
+		&agent.OutputPath,
+		"output-path",
 		"",
 		"",
-		"Data file path, if used will write data to a local file instead of posting",
+		"Output file path, if used will write data to a local file instead of uploading to the preflight server",
 	)
 
 }


### PR DESCRIPTION
Flag --write-to-file allows for a local path to be given to which data is stored.
Only stores data locally if no organization is specified. - This can be added for when organisation is specified if needed.

Signed-off-by: Jamie Leppard <JammyL@users.noreply.github.com>