### PR TITLE
Input/Output Path added to agent.yaml

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -31,6 +31,10 @@ type Config struct {
 	// ClusterID is the cluster that the agent is scanning.
 	ClusterID     string         `yaml:"cluster_id"`
 	DataGatherers []dataGatherer `yaml:"data-gatherers"`
+	// InputPath replaces DataGatherers with input data file
+	InputPath string `yaml:"input-path"`
+	// OutputPath replaces Server with output data file
+	OutputPath string `yaml:"output-path"`
 }
 
 type Endpoint struct {

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -18,6 +18,8 @@ func TestValidConfigLoad(t *testing.T) {
         kind: dummy
         config:
           param-1: "bar"
+      input-path: "/home"
+      output-path: "/nothome"
 `
 
 	loadedConfig, err := ParseConfig([]byte(configFileContents))
@@ -37,6 +39,8 @@ func TestValidConfigLoad(t *testing.T) {
 				},
 			},
 		},
+		InputPath:  "/home",
+		OutputPath: "/nothome",
 	}
 
 	if diff, equal := messagediff.PrettyDiff(expected, loadedConfig); !equal {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -28,7 +28,7 @@ var AuthToken string
 // Period is the number of seconds between scans
 var Period uint
 
-// Agent will run only once if OneShot is enabled
+// OneShot flag causes agent to run once
 var OneShot bool
 
 // CredentialsPath is where the agent will try to loads the credentials. (Experimental)
@@ -138,6 +138,15 @@ func getConfiguration(ctx context.Context) (Config, *client.PreflightClient) {
 
 func gatherAndOutputData(ctx context.Context, config Config, preflightClient *client.PreflightClient) {
 	var readings []*api.DataReading
+
+	// Input/OutputPath flag overwrites agent.yaml configuration
+	if InputPath == "" {
+		InputPath = config.InputPath
+	}
+	if OutputPath == "" {
+		OutputPath = config.OutputPath
+	}
+
 	if InputPath != "" {
 		log.Println("Reading data from", InputPath)
 		data, err := ioutil.ReadFile(InputPath)


### PR DESCRIPTION
This adds two fields to the agent.yaml to specify the input and output path instead of using the flag.