### PR TITLE
exp backoff fails when datagatherers have no error

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -239,16 +239,18 @@ func gatherData(ctx context.Context, config Config) []*api.DataReading {
 				})
 			}
 		}
-		dgError.ErrorFormat = func(es []error) string {
-			points := make([]string, len(es))
-			for i, err := range es {
-				points[i] = fmt.Sprintf("* %s", err)
+		if dgError != nil {
+			dgError.ErrorFormat = func(es []error) string {
+				points := make([]string, len(es))
+				for i, err := range es {
+					points[i] = fmt.Sprintf("* %s", err)
+				}
+				return fmt.Sprintf(
+					"The following %d data gatherer(s) have failed:\n\t%s",
+					len(es), strings.Join(points, "\n\t"))
 			}
-			return fmt.Sprintf(
-				"The following %d data gatherer(s) have failed:\n\t%s",
-				len(es), strings.Join(points, "\n\t"))
 		}
-		return dgError
+		return dgError.ErrorOrNil()
 	}
 
 	err := backoff.RetryNotify(getReadings, backOff, notify)


### PR DESCRIPTION
The error formatting would run even with a nil error
leading to a seg fault.

This now only runs if an error is present.
The return has also been corrected to stop the exp-backoff
always running

Signed-off-by: Jamie Leppard <JammyL@users.noreply.github.com>