### PR TITLE
Increased backoff time for repeated login attempts

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -83,7 +83,7 @@ func init() {
 		&agent.BackoffMaxTime,
 		"backoff-max-time",
 		"",
-		5*time.Minute,
+		10*time.Minute,
 		"Max time for retrying failed data gatherers (given as XhYmZs).",
 	)
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -176,6 +176,8 @@ func gatherAndOutputData(ctx context.Context, config Config, preflightClient *cl
 		log.Println("Data saved locally to", OutputPath)
 	} else {
 		backOff := backoff.NewExponentialBackOff()
+		backOff.InitialInterval = 30 * time.Second
+		backOff.MaxInterval = 3 * time.Minute
 		backOff.MaxElapsedTime = BackoffMaxTime
 		post := func() error {
 			return postData(config, preflightClient, readings)


### PR DESCRIPTION
The exponential backoff algorithm causes svc accountsto be blocked after 11 login attempts.

To stop the accounts being blocked on a single set of login attempts the backoff algorithm has beenslowed down.

At this stage, I am still unsure of the time limit over which these 11 attempts will block an account.

This means that multiple retries of the end-to-end step in the CI pipeline may still block a svc account.

Signed-off-by: Jamie Leppard <JammyL@users.noreply.github.com>