### PR TITLE
Remove basic auth from agent codebase

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -37,13 +37,6 @@ func init() {
 		"./agent.yaml",
 		"Config file location, default is `agent.yaml` in the current working directory.",
 	)
-	agentCmd.PersistentFlags().StringVarP(
-		&agent.AuthToken,
-		"auth-token",
-		"t",
-		"",
-		"Authorization token. If used, it will override the authorization token in the configuration file.",
-	)
 	agentCmd.PersistentFlags().DurationVarP(
 		&agent.Period,
 		"period",

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -18,9 +18,6 @@ import (
 // Config wraps the options for a run of the agent.
 type Config struct {
 	Schedule string `yaml:"schedule"`
-	// Token is the agent token if using basic authentication.
-	// If not provided it will assume OAuth2 authentication.
-	Token string `yaml:"token"`
 	// Deprecated: Endpoint is being replaced with Server.
 	Endpoint Endpoint `yaml:"endpoint"`
 	// Server is the base url for the Preflight server.
@@ -130,13 +127,11 @@ func (c *Config) Dump() (string, error) {
 func (c *Config) validate() error {
 	var result *multierror.Error
 
-	if c.Token == "" {
-		if c.OrganizationID == "" {
-			result = multierror.Append(result, fmt.Errorf("organization_id is required"))
-		}
-		if c.ClusterID == "" {
-			result = multierror.Append(result, fmt.Errorf("cluster_id is required"))
-		}
+	if c.OrganizationID == "" {
+		result = multierror.Append(result, fmt.Errorf("organization_id is required"))
+	}
+	if c.ClusterID == "" {
+		result = multierror.Append(result, fmt.Errorf("cluster_id is required"))
 	}
 
 	if c.Server != "" {

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -11,8 +11,9 @@ import (
 
 func TestValidConfigLoad(t *testing.T) {
 	configFileContents := `
-      token: "12345"
       server: "http://localhost:8080"
+      organization_id: "example"
+      cluster_id: "example-cluster"
       data-gatherers:
       - name: d1
         kind: dummy
@@ -28,8 +29,9 @@ func TestValidConfigLoad(t *testing.T) {
 	}
 
 	expected := Config{
-		Token:  "12345",
-		Server: "http://localhost:8080",
+		Server:         "http://localhost:8080",
+		OrganizationID: "example",
+		ClusterID:      "example-cluster",
 		DataGatherers: []dataGatherer{
 			dataGatherer{
 				Name: "d1",
@@ -54,7 +56,8 @@ func TestValidConfigWithEndpointLoad(t *testing.T) {
         host: example.com
         path: api/v1/data
       schedule: "* * * * *"
-      token: "12345"
+      organization_id: "example"
+      cluster_id: "example-cluster"
       data-gatherers:
       - name: d1
         kind: dummy
@@ -73,8 +76,9 @@ func TestValidConfigWithEndpointLoad(t *testing.T) {
 			Host:     "example.com",
 			Path:     "api/v1/data",
 		},
-		Schedule: "* * * * *",
-		Token:    "12345",
+		Schedule:       "* * * * *",
+		OrganizationID: "example",
+		ClusterID:      "example-cluster",
 		DataGatherers: []dataGatherer{
 			dataGatherer{
 				Name: "d1",
@@ -132,7 +136,8 @@ func TestPartialMissingConfigError(t *testing.T) {
         host: example.com
         path: /api/v1/data
       schedule: "* * * * *"
-      token: "12345"
+      organization_id: "example"
+      cluster_id: "example-cluster"
       data-gatherers:
         - kind: dummy`))
 
@@ -189,7 +194,6 @@ func TestInvalidDataGathered(t *testing.T) {
         host: example.com
         path: /api/v1/data
       schedule: "* * * * *"
-      token: "12345"
       data-gatherers:
         - kind: "foo"`))
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -24,9 +24,6 @@ import (
 // ConfigFilePath is where the agent will try to load the configuration from
 var ConfigFilePath string
 
-// AuthToken is the authorization token that will be used for API calls
-var AuthToken string
-
 // Period is the time waited between scans
 var Period time.Duration
 
@@ -71,13 +68,6 @@ func getConfiguration(ctx context.Context) (Config, *client.PreflightClient) {
 	config, err := ParseConfig(b)
 	if err != nil {
 		log.Fatalf("Failed to parse config file: %s", err)
-	}
-
-	// AuthToken flag takes preference over token in configuration file.
-	if AuthToken == "" {
-		AuthToken = config.Token
-	} else {
-		log.Printf("Using authorization token from flag.")
 	}
 
 	if config.Token != "" {
@@ -128,11 +118,8 @@ func getConfiguration(ctx context.Context) (Config, *client.PreflightClient) {
 			log.Fatalf("Error creating preflight client: %+v", err)
 		}
 	} else {
-		if AuthToken == "" {
-			log.Fatalf("Missing authorization token. Cannot continue.")
-		}
-
-		preflightClient, err = client.NewWithBasicAuth(agentMetadata, AuthToken, baseURL)
+		log.Printf("No credentials file was specified. Starting client with no authentication...")
+		preflightClient, err = client.NewWithNoAuth(agentMetadata, baseURL)
 		if err != nil {
 			log.Fatalf("Error creating preflight client: %+v", err)
 		}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -70,10 +70,6 @@ func getConfiguration(ctx context.Context) (Config, *client.PreflightClient) {
 		log.Fatalf("Failed to parse config file: %s", err)
 	}
 
-	if config.Token != "" {
-		config.Token = "(redacted)"
-	}
-
 	baseURL := config.Server
 	if baseURL == "" {
 		log.Printf("Using deprecated Endpoint configuration. User Server instead.")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,23 +24,18 @@ type PreflightClient struct {
 
 	baseURL string
 
-	// basicAuthToken will be used instead of using OAuth2 based authentication if userID is not set.
-	// It can be empty, meaning that no authentication will be used.
-	basicAuthToken string
-
 	agentMetadata *api.AgentMetadata
 }
 
-// NewWithBasicAuth creates a new client with basic authentication.
-func NewWithBasicAuth(agentMetadata *api.AgentMetadata, authToken, baseURL string) (*PreflightClient, error) {
+// NewWithNoAuth creates a new client with no authentication.
+func NewWithNoAuth(agentMetadata *api.AgentMetadata, baseURL string) (*PreflightClient, error) {
 	if baseURL == "" {
 		return nil, fmt.Errorf("cannot create PreflightClient: baseURL cannot be empty")
 	}
 
 	return &PreflightClient{
-		agentMetadata:  agentMetadata,
-		basicAuthToken: authToken,
-		baseURL:        baseURL,
+		agentMetadata: agentMetadata,
+		baseURL:       baseURL,
 	}, nil
 }
 

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -10,9 +10,7 @@ import (
 // Post performs a post request.
 func (c *PreflightClient) Post(path string, body io.Reader) (*http.Response, error) {
 	var bearer string
-	if !c.usingOAuth2() {
-		bearer = c.basicAuthToken
-	} else {
+	if c.usingOAuth2() {
 		token, err := c.getValidAccessToken()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Removes basic auth from the preflight client inialization.
Still allows preflight client to be not auth.

Related #414

Signed-off-by: Oluwole Fadeyi <tfadeyi@users.noreply.github.com>