### PR TITLE
Add strict flag to agent

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -79,5 +79,12 @@ func init() {
 		10*time.Minute,
 		"Max time for retrying failed data gatherers (given as XhYmZs).",
 	)
+	agentCmd.PersistentFlags().BoolVarP(
+		&agent.StrictMode,
+		"strict",
+		"",
+		false,
+		"Runs agent in strict mode. No retry attempts will be made for a missing data gatherer's data.",
+	)
 
 }

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -17,7 +17,7 @@ import (
 	"github.com/jetstack/preflight/api"
 	"github.com/jetstack/preflight/pkg/client"
 	"github.com/jetstack/preflight/pkg/datagatherer"
-	"github.com/jetstack/preflight/pkg/datagatherer/local"
+	dgerror "github.com/jetstack/preflight/pkg/datagatherer/error"
 	"github.com/jetstack/preflight/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -211,7 +211,7 @@ func gatherData(ctx context.Context, config Config) []*api.DataReading {
 			}
 			dgData, err := dg.Fetch()
 			if err != nil {
-				if _, ok := err.(*local.ConfigError); ok {
+				if _, ok := err.(*dgerror.ConfigError); ok {
 					if StrictMode {
 						err = fmt.Errorf("%s: %v", k, err)
 						dgError = multierror.Append(dgError, err)
@@ -262,7 +262,7 @@ func gatherData(ctx context.Context, config Config) []*api.DataReading {
 			log.Println(err)
 			log.Printf("This will not be retried")
 		} else {
-			log.Printf("All data gatherers successfull")
+			log.Printf("Finished gathering data")
 		}
 	}
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -17,7 +17,7 @@ import (
 	"github.com/jetstack/preflight/api"
 	"github.com/jetstack/preflight/pkg/client"
 	"github.com/jetstack/preflight/pkg/datagatherer"
-	"github.com/jetstack/preflight/pkg/datagatherer/k8s"
+	"github.com/jetstack/preflight/pkg/datagatherer/local"
 	"github.com/jetstack/preflight/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -211,7 +211,7 @@ func gatherData(ctx context.Context, config Config) []*api.DataReading {
 			}
 			dgData, err := dg.Fetch()
 			if err != nil {
-				if _, ok := err.(*k8s.CRDNotFoundError); ok {
+				if _, ok := err.(*local.ConfigError); ok {
 					if StrictMode {
 						err = fmt.Errorf("%s: %v", k, err)
 						dgError = multierror.Append(dgError, err)

--- a/pkg/datagatherer/error/error.go
+++ b/pkg/datagatherer/error/error.go
@@ -1,0 +1,14 @@
+package dgerror
+
+import (
+	"fmt"
+)
+
+// ConfigError is the error type for a misconfiguration. e.g. A missing CRD
+type ConfigError struct {
+	Err string
+}
+
+func (e *ConfigError) Error() string {
+	return fmt.Sprintf("%s", e.Err)
+}

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -121,15 +121,11 @@ type DataGathererDynamic struct {
 
 // CRDNotFoundError is the error type if a CRD is not found
 type CRDNotFoundError struct {
-	Err          string
-	DataGatherer string
+	Err string
 }
 
 func (e *CRDNotFoundError) Error() string {
-	if e.DataGatherer != "" {
-		return fmt.Sprintf("%s: %s", e.DataGatherer, e.Err)
-	}
-	return fmt.Sprintf("unknown data gatherer: %s", e.Err)
+	return fmt.Sprintf("%s", e.Err)
 }
 
 // Fetch will fetch the requested data from the apiserver, or return an error
@@ -155,7 +151,7 @@ func (g *DataGathererDynamic) Fetch() (interface{}, error) {
 		if err != nil {
 			if statusErr, ok := err.(*statusError.StatusError); ok {
 				if statusErr.Status().Code == 404 {
-					return nil, &CRDNotFoundError{Err: fmt.Sprintf("%v", err)}
+					return nil, &CRDNotFoundError{Err: err.Error()}
 				}
 			}
 			return nil, err

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jetstack/preflight/pkg/datagatherer"
+	"github.com/jetstack/preflight/pkg/datagatherer/local"
 	"github.com/pkg/errors"
 	statusError "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -119,15 +120,6 @@ type DataGathererDynamic struct {
 	fieldSelector string
 }
 
-// CRDNotFoundError is the error type if a CRD is not found
-type CRDNotFoundError struct {
-	Err string
-}
-
-func (e *CRDNotFoundError) Error() string {
-	return fmt.Sprintf("%s", e.Err)
-}
-
 // Fetch will fetch the requested data from the apiserver, or return an error
 // if fetching the data fails.
 func (g *DataGathererDynamic) Fetch() (interface{}, error) {
@@ -151,7 +143,7 @@ func (g *DataGathererDynamic) Fetch() (interface{}, error) {
 		if err != nil {
 			if statusErr, ok := err.(*statusError.StatusError); ok {
 				if statusErr.Status().Code == 404 {
-					return nil, &CRDNotFoundError{Err: err.Error()}
+					return nil, &local.ConfigError{Err: err.Error()}
 				}
 			}
 			return nil, err

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/jetstack/preflight/pkg/datagatherer"
-	"github.com/jetstack/preflight/pkg/datagatherer/local"
+	dgerror "github.com/jetstack/preflight/pkg/datagatherer/error"
 	"github.com/pkg/errors"
 	statusError "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,7 +143,7 @@ func (g *DataGathererDynamic) Fetch() (interface{}, error) {
 		if err != nil {
 			if statusErr, ok := err.(*statusError.StatusError); ok {
 				if statusErr.Status().Code == 404 {
-					return nil, &local.ConfigError{Err: err.Error()}
+					return nil, &dgerror.ConfigError{Err: err.Error()}
 				}
 			}
 			return nil, err

--- a/pkg/datagatherer/local/local.go
+++ b/pkg/datagatherer/local/local.go
@@ -46,12 +46,3 @@ func (g *DataGatherer) Fetch() (interface{}, error) {
 	}
 	return dataBytes, nil
 }
-
-// ConfigError is the error type for a misconfiguration. e.g. A missing CRD
-type ConfigError struct {
-	Err string
-}
-
-func (e *ConfigError) Error() string {
-	return fmt.Sprintf("%s", e.Err)
-}

--- a/pkg/datagatherer/local/local.go
+++ b/pkg/datagatherer/local/local.go
@@ -46,3 +46,12 @@ func (g *DataGatherer) Fetch() (interface{}, error) {
 	}
 	return dataBytes, nil
 }
+
+// ConfigError is the error type for a misconfiguration. e.g. A missing CRD
+type ConfigError struct {
+	Err string
+}
+
+func (e *ConfigError) Error() string {
+	return fmt.Sprintf("%s", e.Err)
+}


### PR DESCRIPTION
Agent will hard fail if a data gatherer is defined for a missing CRD.

Related [#510](https://github.com/jetstack/preflight-platform/issues/510)