### PR TITLE
Send gather time and cluster ID in agent upload

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -3,4 +3,7 @@ package api
 // AgentMetadata is metadata about the agent.
 type AgentMetadata struct {
 	Version string `json:"version"`
+	// ClusterID is the name of the cluster or host where the agent is running.
+	// It may send data for other clusters in its datareadings.
+	ClusterID string `json:"cluster_id"`
 }

--- a/api/datareading.go
+++ b/api/datareading.go
@@ -1,9 +1,13 @@
 package api
 
+import "time"
+
 // DataReadingsPost is the payload in the upload request.
 type DataReadingsPost struct {
 	AgentMetadata *AgentMetadata `json:"agent_metadata"`
-	DataReadings  []*DataReading `json:"data_readings"`
+	// DataGatherTime represents the time that the data readings were gathered
+	DataGatherTime time.Time      `json:"data_gather_time"`
+	DataReadings   []*DataReading `json:"data_readings"`
 }
 
 // DataReading is the output of a DataGatherer.

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -108,7 +108,8 @@ func getConfiguration(ctx context.Context) (Config, *client.PreflightClient) {
 	}
 
 	agentMetadata := &api.AgentMetadata{
-		Version: version.PreflightVersion,
+		Version:   version.PreflightVersion,
+		ClusterID: config.ClusterID,
 	}
 	var preflightClient *client.PreflightClient
 	if credentials != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"time"
 
 	"github.com/jetstack/preflight/api"
 )
@@ -77,8 +78,9 @@ func (c *PreflightClient) usingOAuth2() bool {
 // PostDataReadings sends a slice of readings to Preflight.
 func (c *PreflightClient) PostDataReadings(orgID string, readings []*api.DataReading) error {
 	payload := api.DataReadingsPost{
-		AgentMetadata: c.agentMetadata,
-		DataReadings:  readings,
+		AgentMetadata:  c.agentMetadata,
+		DataGatherTime: time.Now(),
+		DataReadings:   readings,
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -79,7 +79,7 @@ func (c *PreflightClient) usingOAuth2() bool {
 func (c *PreflightClient) PostDataReadings(orgID string, readings []*api.DataReading) error {
 	payload := api.DataReadingsPost{
 		AgentMetadata:  c.agentMetadata,
-		DataGatherTime: time.Now(),
+		DataGatherTime: time.Now().UTC(),
 		DataReadings:   readings,
 	}
 	data, err := json.Marshal(payload)


### PR DESCRIPTION
This will allow agent data to be categorized and stored in preparation
for processing async on the backend.

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>