### PR TITLE
Remove last-applied... annotation from metadata

### DIFF
--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -200,15 +200,21 @@ func redactList(list *unstructured.UnstructuredList) error {
 					secret.Object["data"] = map[string]interface{}{}
 				}
 
-				// Redact last-applied-configuration annotation if set
-				annotations, present := secret.Object["annotations"].(map[string]interface{})
-				if present {
-					_, annotationPresent := annotations["kubectl.kubernetes.io/last-applied-configuration"]
-					if annotationPresent {
-						annotations["kubectl.kubernetes.io/last-applied-configuration"] = "redacted"
+				metadata, metadataPresent := secret.Object["metadata"].(map[string]interface{})
+				if metadataPresent {
+					// Redact last-applied-configuration annotation if set
+					annotations, present := metadata["annotations"].(map[string]interface{})
+					if present {
+						_, annotationPresent := annotations["kubectl.kubernetes.io/last-applied-configuration"]
+						if annotationPresent {
+							annotations["kubectl.kubernetes.io/last-applied-configuration"] = "redacted"
+						}
+						metadata["annotations"] = annotations
 					}
-					secret.Object["annotations"] = annotations
+					secret.Object["metadata"] = metadata
 				}
+				// break when the object has been processed as a secret, no
+				// other kinds have redact modifications
 				break
 			}
 		}


### PR DESCRIPTION
I appear to have made an error in https://github.com/jetstack/preflight/pull/152.

It is looking for field annotations on objects which is never set,
annotation are nested under metadata.

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>