### PR TITLE
Implement more generic means of filtering uploaded objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.8 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect
+	github.com/Jeffail/gabs v1.1.1
+	github.com/Jeffail/gabs/v2 v2.6.0
 	github.com/aws/aws-sdk-go v1.34.10
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/d4l3k/messagediff v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,9 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Jeffail/gabs v1.1.1 h1:V0uzR08Hj22EX8+8QMhyI9sX2hwRu+/RJhJUmnwda/E=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
+github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
+github.com/Jeffail/gabs/v2 v2.6.0 h1:WdCnGaDhNa4LSRTMwhLZzJ7SRDXjABNP13SOKvCpL5w=
+github.com/Jeffail/gabs/v2 v2.6.0/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -176,15 +176,7 @@ func redactList(list *unstructured.UnstructuredList) error {
 		for _, gvk := range gvks {
 			// If this item is a Secret then we need to redact it.
 			if gvk.Kind == "Secret" && (gvk.Group == "core" || gvk.Group == "") {
-				Select([]string{
-					"kind",
-					"apiVersion",
-					"metadata.name",
-					"metadata.namespace",
-					"type",
-					"/data/tls.crt",
-					"/data/ca.crt",
-				}, &resource)
+				Select(SecretSelectedFields, &resource)
 
 				// break when the object has been processed as a secret, no
 				// other kinds have redact modifications

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// Select removes all but the supplied fields from the resource
 func Select(fields []string, resource *unstructured.Unstructured) error {
 	// convert the object to JSON for field filtering
 	asJSON, err := json.Marshal(resource)
@@ -43,6 +44,46 @@ func Select(fields []string, resource *unstructured.Unstructured) error {
 
 	// load the filtered JSON back into the resource
 	err = json.Unmarshal(filteredObject.Bytes(), resource)
+	if err != nil {
+		return fmt.Errorf("failed to update resource: %s", err)
+	}
+
+	return nil
+}
+
+// Redact removes the supplied fields from the resource
+func Redact(fields []string, resource *unstructured.Unstructured) error {
+	// convert the object to JSON for field filtering
+	asJSON, err := json.Marshal(resource)
+	if err != nil {
+		return fmt.Errorf("failed to marshal json for resource: %s", err)
+	}
+
+	// parse the JSON for processing in gabs
+	jsonParsed, err := gabs.ParseJSON(asJSON)
+	if err != nil {
+		return fmt.Errorf("failed to parse generated json for resource: %s", err)
+	}
+
+	// craft a new object excluding redacted fields
+	for _, v := range fields {
+		// also support JSONPointers for keys containing '.' chars
+		if strings.HasPrefix(v, "/") {
+			pathComponents := strings.Split(v, "/")[1:]
+			if jsonParsed.Exists(pathComponents...) {
+				jsonParsed.Delete(pathComponents...)
+			}
+		} else {
+			if jsonParsed.ExistsP(v) {
+				jsonParsed.DeleteP(v)
+			}
+		}
+	}
+
+	fmt.Println(jsonParsed.String())
+
+	// load the filtered JSON back into the resource
+	err = json.Unmarshal(jsonParsed.Bytes(), resource)
 	if err != nil {
 		return fmt.Errorf("failed to update resource: %s", err)
 	}

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -80,8 +80,6 @@ func Redact(fields []string, resource *unstructured.Unstructured) error {
 		}
 	}
 
-	fmt.Println(jsonParsed.String())
-
 	// load the filtered JSON back into the resource
 	err = json.Unmarshal(jsonParsed.Bytes(), resource)
 	if err != nil {

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -1,0 +1,48 @@
+package k8s
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Jeffail/gabs/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func Select(fields []string, resource *unstructured.Unstructured) error {
+	// convert the object to JSON for field filtering
+	asJSON, err := json.Marshal(resource)
+	if err != nil {
+		return fmt.Errorf("failed to marshal json for resource: %s", err)
+	}
+
+	// parse the JSON for processing in gabs
+	jsonParsed, err := gabs.ParseJSON(asJSON)
+	if err != nil {
+		return fmt.Errorf("failed to parse generated json for resource: %s", err)
+	}
+
+	// craft a new object containing only selected fields
+	filteredObject := gabs.New()
+	for _, v := range fields {
+		// also support JSONPointers for keys containing '.' chars
+		if strings.HasPrefix(v, "/") {
+			gObject, err := jsonParsed.JSONPointer(v)
+			if err != nil {
+				return fmt.Errorf("failed to select data at JSONPointer: %s", v)
+			}
+			pathComponents := strings.Split(v, "/")
+			filteredObject.Set(gObject.Data(), pathComponents[1:]...)
+		} else {
+			filteredObject.SetP(jsonParsed.Path(v).Data(), v)
+		}
+	}
+
+	// load the filtered JSON back into the resource
+	err = json.Unmarshal(filteredObject.Bytes(), resource)
+	if err != nil {
+		return fmt.Errorf("failed to update resource: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -9,6 +9,18 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// SecretSelectedFields is the list of fields sent from Secret objects to the
+// backend
+var SecretSelectedFields = []string{
+	"kind",
+	"apiVersion",
+	"metadata.name",
+	"metadata.namespace",
+	"type",
+	"/data/tls.crt",
+	"/data/ca.crt",
+}
+
 // Select removes all but the supplied fields from the resource
 func Select(fields []string, resource *unstructured.Unstructured) error {
 	// convert the object to JSON for field filtering

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -29,12 +29,15 @@ func Select(fields []string, resource *unstructured.Unstructured) error {
 		if strings.HasPrefix(v, "/") {
 			gObject, err := jsonParsed.JSONPointer(v)
 			if err != nil {
-				return fmt.Errorf("failed to select data at JSONPointer: %s", v)
+				// fail to select field if missing, just continue
+				continue
 			}
 			pathComponents := strings.Split(v, "/")
 			filteredObject.Set(gObject.Data(), pathComponents[1:]...)
 		} else {
-			filteredObject.SetP(jsonParsed.Path(v).Data(), v)
+			if jsonParsed.ExistsP(v) {
+				filteredObject.SetP(jsonParsed.Path(v).Data(), v)
+			}
 		}
 	}
 

--- a/pkg/datagatherer/k8s/fieldfilter_test.go
+++ b/pkg/datagatherer/k8s/fieldfilter_test.go
@@ -56,3 +56,30 @@ func TestFieldSelector(t *testing.T) {
 		t.Fatalf("unexpected JSON: \ngot \n%s\nwant\n%s", string(bytes), expectedJSON)
 	}
 }
+
+func TestFieldSelectorMissingSelectedField(t *testing.T) {
+	resource := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "Secret",
+		},
+	}
+
+	fieldsToSelect := []string{
+		"kind",
+		"missing",
+		"/missing",
+	}
+
+	err := Select(fieldsToSelect, resource)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	bytes, err := json.MarshalIndent(resource, "", "    ")
+	expectedJSON := `{
+    "kind": "Secret"
+}`
+	if string(bytes) != expectedJSON {
+		t.Fatalf("unexpected JSON: \ngot \n%s\nwant\n%s", string(bytes), expectedJSON)
+	}
+}

--- a/pkg/datagatherer/k8s/fieldfilter_test.go
+++ b/pkg/datagatherer/k8s/fieldfilter_test.go
@@ -1,0 +1,58 @@
+package k8s
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestFieldSelector(t *testing.T) {
+	resource := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":                       "example",
+				"namespace":                  "example",
+				"last-applied-configuration": "secret",
+			},
+			"type": "kubernetes.io/tls",
+			"data": map[string]interface{}{
+				"tls.crt": "cert data",
+				"tls.key": "secret",
+			},
+		},
+	}
+
+	fieldsToSelect := []string{
+		"apiVersion",
+		"kind",
+		"metadata.name",
+		"metadata.namespace",
+		"type",
+		"/data/tls.crt",
+	}
+
+	err := Select(fieldsToSelect, resource)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	bytes, err := json.MarshalIndent(resource, "", "    ")
+	expectedJSON := `{
+    "apiVersion": "v1",
+    "data": {
+        "tls.crt": "cert data"
+    },
+    "kind": "Secret",
+    "metadata": {
+        "name": "example",
+        "namespace": "example"
+    },
+    "type": "kubernetes.io/tls"
+}`
+	if string(bytes) != expectedJSON {
+		t.Fatalf("unexpected JSON: \ngot \n%s\nwant\n%s", string(bytes), expectedJSON)
+	}
+}

--- a/pkg/datagatherer/k8s/fieldfilter_test.go
+++ b/pkg/datagatherer/k8s/fieldfilter_test.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func TestFieldSelector(t *testing.T) {
+func TestSelect(t *testing.T) {
 	resource := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
@@ -57,7 +57,7 @@ func TestFieldSelector(t *testing.T) {
 	}
 }
 
-func TestFieldSelectorMissingSelectedField(t *testing.T) {
+func TestSelectMissingSelectedField(t *testing.T) {
 	resource := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind": "Secret",
@@ -65,12 +65,84 @@ func TestFieldSelectorMissingSelectedField(t *testing.T) {
 	}
 
 	fieldsToSelect := []string{
-		"kind",
+		"kind", // required for unstructured unmarshal
 		"missing",
 		"/missing",
 	}
 
 	err := Select(fieldsToSelect, resource)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	bytes, err := json.MarshalIndent(resource, "", "    ")
+	expectedJSON := `{
+    "kind": "Secret"
+}`
+	if string(bytes) != expectedJSON {
+		t.Fatalf("unexpected JSON: \ngot \n%s\nwant\n%s", string(bytes), expectedJSON)
+	}
+}
+
+func TestRedact(t *testing.T) {
+	resource := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":                       "example",
+				"namespace":                  "example",
+				"last-applied-configuration": "secret",
+			},
+			"type": "kubernetes.io/tls",
+			"data": map[string]interface{}{
+				"tls.crt": "cert data",
+				"tls.key": "secret",
+			},
+		},
+	}
+
+	fieldsToRedact := []string{
+		"metadata.last-applied-configuration",
+		"/data/tls.key",
+	}
+
+	err := Redact(fieldsToRedact, resource)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	bytes, err := json.MarshalIndent(resource, "", "    ")
+	expectedJSON := `{
+    "apiVersion": "v1",
+    "data": {
+        "tls.crt": "cert data"
+    },
+    "kind": "Secret",
+    "metadata": {
+        "name": "example",
+        "namespace": "example"
+    },
+    "type": "kubernetes.io/tls"
+}`
+	if string(bytes) != expectedJSON {
+		t.Fatalf("unexpected JSON: \ngot \n%s\nwant\n%s", string(bytes), expectedJSON)
+	}
+}
+
+func TestRedactMissingField(t *testing.T) {
+	resource := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "Secret",
+		},
+	}
+
+	fieldsToRedact := []string{
+		"missing",
+		"/missing",
+	}
+
+	err := Redact(fieldsToRedact, resource)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}


### PR DESCRIPTION
This can also be imported by the backend.

Also changes uploaded secret data to only contain a fixed allowlist of keys within the object.