### PR TITLE
Correct JSONPointer for redacting last-applied

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.8 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect
-	github.com/Jeffail/gabs v1.1.1
 	github.com/Jeffail/gabs/v2 v2.6.0
 	github.com/aws/aws-sdk-go v1.34.10
 	github.com/cenkalti/backoff v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -90,7 +90,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Jeffail/gabs v1.1.1 h1:V0uzR08Hj22EX8+8QMhyI9sX2hwRu+/RJhJUmnwda/E=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
-github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
 github.com/Jeffail/gabs/v2 v2.6.0 h1:WdCnGaDhNa4LSRTMwhLZzJ7SRDXjABNP13SOKvCpL5w=
 github.com/Jeffail/gabs/v2 v2.6.0/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -156,7 +156,7 @@ func gatherAndOutputData(ctx context.Context, config Config, preflightClient *cl
 	}
 
 	if OutputPath != "" {
-		data, err := json.MarshalIndent(readings, " ", " ")
+		data, err := json.MarshalIndent(readings, "", "  ")
 		err = ioutil.WriteFile(OutputPath, data, 0644)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -183,11 +183,10 @@ func redactList(list *unstructured.UnstructuredList) error {
 				break
 			}
 
-			// remove managedFields from all resources
-			Redact([]string{
-				"metadata.managedFields",
-			}, &resource)
 		}
+
+		// remove managedFields from all resources
+		Redact(RedactFields, &resource)
 
 		// update the object in the list
 		list.Items[i] = resource

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -24,7 +24,7 @@ var SecretSelectedFields = []string{
 // RedactFields are removed from all objects
 var RedactFields = []string{
 	"metadata.managedFields",
-	"/metadata.annotations/kubectl.kubernetes.io~1last-applied-configuration",
+	"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration",
 }
 
 // Select removes all but the supplied fields from the resource


### PR DESCRIPTION
This will only make a difference for non-secret resources. Secret
resources lose this annotation via selection.

Also use the Redact fields package var

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>