### PR TITLE
Update version checker data gatherer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/googleapis/gnostic v0.5.1 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/imdario/mergo v0.3.11 // indirect
-	github.com/jetstack/version-checker v0.2.1
+	github.com/jetstack/version-checker v0.2.2-0.20201118163251-4bab9ef088ef
 	github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9
 	github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 // indirect
 	github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b // indirect

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ github.com/jarcoal/httpmock v1.0.1 h1:OXIOrglWeSllwHQGJ5X4PX4hFZK1DPCXSJVhMSJacg
 github.com/jarcoal/httpmock v1.0.1/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jetstack/version-checker v0.2.1 h1:fTkj1ztb6WP4gMQTROHYAUHJMFMuZOBRRLMrZa0bed4=
 github.com/jetstack/version-checker v0.2.1/go.mod h1:908YLy8SWIJMJoYQpZf2QIRAvBvZ2WM0ylNiCrK8Vvg=
+github.com/jetstack/version-checker v0.2.2-0.20201118163251-4bab9ef088ef h1:bsZIh0Y7TogJfmseOARM9OeZzctSDuuHuJQTQhl97Mo=
+github.com/jetstack/version-checker v0.2.2-0.20201118163251-4bab9ef088ef/go.mod h1:908YLy8SWIJMJoYQpZf2QIRAvBvZ2WM0ylNiCrK8Vvg=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/pkg/datagatherer/versionchecker/fixtures/manifest-100.json
+++ b/pkg/datagatherer/versionchecker/fixtures/manifest-100.json
@@ -1,5 +1,7 @@
 {
   "schemaVersion": 1,
   "name": "jetstack/example",
-  "tag": "v1.0.0"
+  "tag": "v1.0.0",
+  "architecture":"amd64",
+  "os":""
 }

--- a/pkg/datagatherer/versionchecker/fixtures/manifest-101.json
+++ b/pkg/datagatherer/versionchecker/fixtures/manifest-101.json
@@ -1,5 +1,7 @@
 {
   "schemaVersion": 1,
   "name": "jetstack/example",
-  "tag": "v1.0.1"
+  "tag": "v1.0.1",
+  "architecture":"amd64",
+  "os":""
 }

--- a/pkg/datagatherer/versionchecker/fixtures/nodes.json
+++ b/pkg/datagatherer/versionchecker/fixtures/nodes.json
@@ -1,0 +1,30 @@
+{
+    "apiVersion": "v1",
+    "kind": "List",
+    "metadata": {
+      "resourceVersion": "",
+      "selfLink": ""
+    },
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "creationTimestamp": "2020-11-24T16:04:38Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/os": "",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "control-plane",
+                    "kubernetes.io/os": ""
+                },
+                "name": "control-plane",
+                "resourceVersion": "167265",
+                "selfLink": "/api/v1/nodes/control-plane",
+                "uid": "d966826d-e63c-487c-a769-cb02098b95fd"
+            },
+            "spec": {},
+            "status": {}
+        }
+    ]
+}

--- a/pkg/datagatherer/versionchecker/fixtures/pods.json.tmpl
+++ b/pkg/datagatherer/versionchecker/fixtures/pods.json.tmpl
@@ -31,6 +31,7 @@
         "uid": "efff9dae-28ca-42c3-be70-970731c44f67"
       },
       "spec": {
+        "nodeName": "control-plane",
         "containers": [
           {
             "name": "example",


### PR DESCRIPTION
Updating version checker data gatherer to support multi-arch images.
This PR uses the packages from the https://github.com/jetstack/version-checker/tree/58-add-arch-and-os-checks
branch of version-checker.
With this change checks will be performed on the image for the correct architecture, so if node is amd64 the check is done on images with amd64. This won't fix the issues seen with fat manifests [#58](https://github.com/jetstack/version-checker/issues/58).
![image](https://user-images.githubusercontent.com/16049411/100126514-f1571700-2e75-11eb-9273-46efd7eeb7ec.png)

![image](https://user-images.githubusercontent.com/16049411/100126566-0338ba00-2e76-11eb-8928-efb7351f272e.png)


Signed-off-by: oluwole.fadeyi <oluwole.fadeyi@jetstack.io>