### PR TITLE
A Preflight Agent Helm Chart for use by the Jetstack Secure package on Google Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,44 @@ taking place in the SaaS backend.
 The following instructions walk through the installation of the Preflight agent
 to gather data about cluster pods and send them to the backend for analysis.
 
+### Recommended Installation: Using Jetstack Secure
+
+The preferred way to install the Preflight agent is to sign in to https://platform.jetstack.io/
+and follow the instructions there.
+For example, to configure the agent for "Machine Identity / Cert Inventory":
+
+1. Visit https://platform.jetstack.io/
+2. Click the "Machine Identity" button, in the tool bar on the left
+3. Click "ADD CLUSTER"
+4. Follow the instructions
+5. Click "COPY COMMAND TO CLIPBOARD" to copy the credentials and configuration command to the clipboard
+
+
+### Helm Installation
+
+You can install the Preflight agent using Helm, as follows, but this is not recommended:
+
+```
+helm install --create-namespace --namespace jetstack-secure jetstack-secure deploy/charts/preflight
+```
+
+Next you will need to register the agent.
+For example, to configure the agent for "Machine Identity / Cert Inventory", please follow these steps:
+
+1. Visit https://platform.jetstack.io/
+2. Click the "Machine Identity" button, in the tool bar on the left
+3. Click "ADD CLUSTER"
+4. Follow the instructions
+5. Click "COPY COMMAND TO CLIPBOARD" to copy the credentials and configuration command to the clipboard
+6. Paste, inspect and then execute the command in your terminal
+
+
+### Manual Installation
+
+You can install the agent from scratch, by manually creating deployment manifests 
+and then using `kubectl apply` to deploy the agent to the cluster,
+but this is not recommended.
+
 **To complete the secret manifest below, you will need to have a Preflight
 token.**
 

--- a/deploy/charts/README.md
+++ b/deploy/charts/README.md
@@ -1,0 +1,1 @@
+# Helm Charts

--- a/deploy/charts/preflight/.helmignore
+++ b/deploy/charts/preflight/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/preflight/Chart.yaml
+++ b/deploy/charts/preflight/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: preflight
+description: A Helm chart for Kubernetes
+
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.27"

--- a/deploy/charts/preflight/templates/NOTES.txt
+++ b/deploy/charts/preflight/templates/NOTES.txt
@@ -1,0 +1,10 @@
+Congratulations! The Jetstack Secure Agent is now installed.
+
+To register the agent, please follow these steps:
+
+1. Visit https://platform.jetstack.io/
+2. Click the "Machine Identity" button, in the tool bar on the left
+3. Click "ADD CLUSTER"
+4. Follow the instructions
+5. Click "COPY COMMAND TO CLIPBOARD" to copy the credentials and configuration command to the clipboard
+6. Paste, inspect and then execute the command in your terminal

--- a/deploy/charts/preflight/templates/_helpers.tpl
+++ b/deploy/charts/preflight/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "preflight.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "preflight.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "preflight.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "preflight.labels" -}}
+helm.sh/chart: {{ include "preflight.chart" . }}
+{{ include "preflight.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "preflight.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "preflight.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "preflight.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "preflight.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/preflight/templates/agent_installation.yaml
+++ b/deploy/charts/preflight/templates/agent_installation.yaml
@@ -172,6 +172,10 @@ spec:
       {{- include "preflight.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "preflight.selectorLabels" . | nindent 8 }}
     spec:

--- a/deploy/charts/preflight/templates/agent_installation.yaml
+++ b/deploy/charts/preflight/templates/agent_installation.yaml
@@ -158,7 +158,7 @@ spec:
           secretName: agent-credentials
       containers:
       - name: agent
-        image: quay.io/jetstack/preflight:v0.1.27
+        image: "quay.io/jetstack/preflight:v{{ .Chart.AppVersion }}"
         args:
         - "agent"
         - "-c"

--- a/deploy/charts/preflight/templates/agent_installation.yaml
+++ b/deploy/charts/preflight/templates/agent_installation.yaml
@@ -1,0 +1,190 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jetstack-secure
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent
+  namespace: jetstack-secure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jetstack-secure-agent-node-reader
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jetstack-secure-agent-secret-reader
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jetstack-secure-agent-cert-manager-reader
+rules:
+- apiGroups: ["cert-manager.io"]
+  resources:
+  - certificates
+  - certificaterequests
+  - issuers
+  - clusterissuers
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jetstack-secure-agent-googlecas-reader
+rules:
+- apiGroups: ["cas-issuer.jetstack.io"]
+  resources:
+  - googlecasissuers
+  - googlecasclusterissuers
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jetstack-secure-agent-get-webhooks
+rules:
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jetstack-secure-agent-secret-reader
+roleRef:
+  kind: ClusterRole
+  name: jetstack-secure-agent-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: agent
+  namespace: jetstack-secure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jetstack-secure-agent-cert-manager-reader
+roleRef:
+  kind: ClusterRole
+  name: jetstack-secure-agent-cert-manager-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: agent
+  namespace: jetstack-secure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jetstack-secure-agent-googlecas-reader
+roleRef:
+  kind: ClusterRole
+  name: jetstack-secure-agent-googlecas-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: agent
+  namespace: jetstack-secure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jetstack-secure-agent-get-webhooks
+roleRef:
+  kind: ClusterRole
+  name: jetstack-secure-agent-get-webhooks
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: agent
+  namespace: jetstack-secure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jetstack-secure-agent-node-reader
+roleRef:
+  kind: ClusterRole
+  name: jetstack-secure-agent-node-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: agent
+  namespace: jetstack-secure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jetstack-secure-agent-cluster-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: agent
+  namespace: jetstack-secure
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent
+  namespace: jetstack-secure
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agent
+    spec:
+      serviceAccountName: agent
+      volumes:
+      - name: config
+        configMap:
+          name: agent-config
+      - name: credentials
+        secret:
+          secretName: agent-credentials
+      containers:
+      - name: agent
+        image: quay.io/jetstack/preflight:v0.1.27
+        args:
+        - "agent"
+        - "-c"
+        - "/etc/jetstack-secure/agent/config/config.yaml"
+        - "-k"
+        - "/etc/jetstack-secure/agent/credentials/credentials.json"
+        - "-p"
+        - "0h1m0s"
+        volumeMounts:
+        - name: config
+          mountPath: "/etc/jetstack-secure/agent/config"
+          readOnly: true
+        - name: credentials
+          mountPath: "/etc/jetstack-secure/agent/credentials"
+          readOnly: true
+        resources:
+          requests:
+            memory: "200Mi"
+            cpu: "200m"
+          limits:
+            memory: "200Mi"
+            cpu: "200m"

--- a/deploy/charts/preflight/templates/agent_installation.yaml
+++ b/deploy/charts/preflight/templates/agent_installation.yaml
@@ -2,11 +2,15 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: agent
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: jetstack-secure-agent-node-reader
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -16,6 +20,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: jetstack-secure-agent-secret-reader
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -25,6 +31,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: jetstack-secure-agent-cert-manager-reader
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["cert-manager.io"]
   resources:
@@ -38,6 +46,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: jetstack-secure-agent-googlecas-reader
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["cas-issuer.jetstack.io"]
   resources:
@@ -49,6 +59,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: jetstack-secure-agent-get-webhooks
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:
@@ -60,6 +72,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: jetstack-secure-agent-secret-reader
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 roleRef:
   kind: ClusterRole
   name: jetstack-secure-agent-secret-reader
@@ -73,6 +87,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: jetstack-secure-agent-cert-manager-reader
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 roleRef:
   kind: ClusterRole
   name: jetstack-secure-agent-cert-manager-reader
@@ -86,6 +102,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: jetstack-secure-agent-googlecas-reader
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 roleRef:
   kind: ClusterRole
   name: jetstack-secure-agent-googlecas-reader
@@ -99,6 +117,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: jetstack-secure-agent-get-webhooks
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 roleRef:
   kind: ClusterRole
   name: jetstack-secure-agent-get-webhooks
@@ -112,6 +132,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: jetstack-secure-agent-node-reader
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 roleRef:
   kind: ClusterRole
   name: jetstack-secure-agent-node-reader
@@ -125,6 +147,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: jetstack-secure-agent-cluster-viewer
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -138,15 +162,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: agent
+  labels:
+    {{- include "preflight.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: agent
+      {{- include "preflight.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: agent
+        {{- include "preflight.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: agent
       volumes:

--- a/deploy/charts/preflight/templates/agent_installation.yaml
+++ b/deploy/charts/preflight/templates/agent_installation.yaml
@@ -158,7 +158,7 @@ spec:
           secretName: agent-credentials
       containers:
       - name: agent
-        image: "quay.io/jetstack/preflight:v{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:v{{ .Chart.AppVersion }}"
         args:
         - "agent"
         - "-c"

--- a/deploy/charts/preflight/templates/agent_installation.yaml
+++ b/deploy/charts/preflight/templates/agent_installation.yaml
@@ -1,13 +1,7 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: jetstack-secure
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: agent
-  namespace: jetstack-secure
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -73,7 +67,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: agent
-  namespace: jetstack-secure
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -86,7 +80,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: agent
-  namespace: jetstack-secure
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -99,7 +93,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: agent
-  namespace: jetstack-secure
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -112,7 +106,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: agent
-  namespace: jetstack-secure
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -125,7 +119,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: agent
-  namespace: jetstack-secure
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -138,13 +132,12 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: agent
-  namespace: jetstack-secure
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: agent
-  namespace: jetstack-secure
 spec:
   replicas: 1
   selector:

--- a/deploy/charts/preflight/values.yaml
+++ b/deploy/charts/preflight/values.yaml
@@ -1,0 +1,2 @@
+image:
+  repository: quay.io/jetstack/preflight

--- a/deploy/charts/preflight/values.yaml
+++ b/deploy/charts/preflight/values.yaml
@@ -1,2 +1,4 @@
 image:
   repository: quay.io/jetstack/preflight
+
+podAnnotations: {}


### PR DESCRIPTION
We want to install the Preflight Agent as part of the [jetstack-secure package on Google Cloud Marketplace](https://github.com/jetstack/jsp-gcm/).
For this, we need to create a Helm chart for the preflight agent,
so I thought I may as well put the chart here.

I used the `agent_installation.yaml`  from https://platform.jetstack.io/agent_installation.yaml as described in the installation instructions in the "Machine Identity / Cert Inventory" section of that site.

The installation instructions in the README of this repo seem directed at the alternative Preflight configuration of the agent.

I have only looked at the certinventory version of the agent_installation.yaml. 
I have not looked at https://platform.jetstack.io/preflight_agent_installation.yaml

I'm not sure how to reconcile those two different configurations.
Perhaps I could rename this chart to "preflight-certinventory" or something.

Anyway, please take a look, and let me know what you think.
If you prefer not to include this chart in the repo, I can always add it to https://github.com/jetstack/jsp-gcm/ instead.

xref: https://github.com/jetstack/preflight/issues/137 https://github.com/jetstack/jsp-gcm/issues/8

```release-note
A Helm chart for easier / customizable installation of the agent
```