### PR TITLE
Use new auth server domain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ GOARCH:=$(shell go env GOARCH)
 DOCKER_IMAGE?=quay.io/jetstack/preflight
 DOCKER_IMAGE_TAG?=$(DOCKER_IMAGE):$(VERSION)
 
-# OAuth2 config for the agent to work with preflight.jetstack.io
+# OAuth2 config for the agent to work with platform.jetstack.io
 OAUTH_CLIENT_ID?=k3TrDbfLhCgnpAbOiiT2kIE1AbovKzjo
 OAUTH_CLIENT_SECRET?=f39w_3KT9Vp0VhzcPzvh-uVbudzqCFmHER3Huj0dvHgJwVrjxsoOQPIw_1SDiCfa
-OAUTH_AUTH_SERVER_DOMAIN?=jetstack-prod.eu.auth0.com
+OAUTH_AUTH_SERVER_DOMAIN?=auth.jetstack.io
 
 define LDFLAGS
 -X "github.com/jetstack/preflight/pkg/version.PreflightVersion=$(VERSION)" \


### PR DESCRIPTION
We are transitioning to a new domain for the auth server. This configures the new domain in the agent binary.

We are going to be backward compatible, so old agents can run with the old domain.