### PR TITLE
Change default config to be valid

### DIFF
--- a/agent.yaml
+++ b/agent.yaml
@@ -1,9 +1,6 @@
-schedule: "* * * *"
-token: ewogICJjbHVzdGVyIjogIm15IGNsdXN0ZXIiLAogICJ0b2tlbiI6ICJleGFtcGxlIgp9Cg==
-endpoint:
-  protocol: http
-  host: "localhost:8080"
-  path: "/api/v1/datareadings"
+server: "https://platform.jetstack.io"
+organization_id: "my-organization"
+cluster_id: "my_cluster"
 data-gatherers:
 - kind: "dummy"
   name: "dummy"


### PR DESCRIPTION
The default config was not valid as it was using an old format. These changes make it valid.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>