### PR TITLE
Introducing informers to dynamic dg

### DIFF
--- a/api/datareading.go
+++ b/api/datareading.go
@@ -25,12 +25,6 @@ type DataReading struct {
 type GatheredResource struct {
 	// Resource is a reference to a k8s object that was found by the informer
 	// should be of type unstructured.Unstructured, raw Object
-	Resource   interface{}               `json:"resource"`
-	Properties *GatheredResourceMetadata `json:"item_metadata,omitempty"`
-}
-
-// GatheredResourceMetadata boundles additional platform metadata for a
-// gathered k8s resource
-type GatheredResourceMetadata struct {
-	DeletedAt *Time `json:"deletedAt,omitempty"`
+	Resource  interface{} `json:"resource"`
+	DeletedAt *Time       `json:"deletedAt,omitempty"`
 }

--- a/api/datareading.go
+++ b/api/datareading.go
@@ -8,6 +8,7 @@ type DataReadingsPost struct {
 	// DataGatherTime represents the time that the data readings were gathered
 	DataGatherTime time.Time      `json:"data_gather_time"`
 	DataReadings   []*DataReading `json:"data_readings"`
+	SchemaVersion  string         `json:"schema_version"`
 }
 
 // DataReading is the output of a DataGatherer.
@@ -18,4 +19,18 @@ type DataReading struct {
 	DataGatherer string      `json:"data-gatherer"`
 	Timestamp    Time        `json:"timestamp"`
 	Data         interface{} `json:"data"`
+}
+
+// GatheredResource wraps the raw k8s resource that is sent to the jetstack secure backend
+type GatheredResource struct {
+	// Resource is a reference to a k8s object that was found by the informer
+	// should be of type unstructured.Unstructured, raw Object
+	Resource   interface{}               `json:"resource"`
+	Properties *GatheredResourceMetadata `json:"item_metadata,omitempty"`
+}
+
+// GatheredResourceMetadata boundles additional platform metadata for a
+// gathered k8s resource
+type GatheredResourceMetadata struct {
+	DeletedAt *Time `json:"deletedAt,omitempty"`
 }

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/pmylund/go-cache v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -779,6 +779,9 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmylund/go-cache v1.0.0 h1:jbJMNhn4LhBfb3dRejPlnjxSiokDt4qO5NWt8mMi+UE=
+github.com/pmylund/go-cache v2.1.0+incompatible h1:n+7K51jLz6a3sCvff3BppuCAkixuDHuJ/C57Vw/XjTE=
+github.com/pmylund/go-cache v2.1.0+incompatible/go.mod h1:hmz95dGvINpbRZGsqPcd7B5xXY5+EKb5PpGhQY3NTHk=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021 h1:0XM1XL/OFFJjXsYXlG30spTkV/E9+gmd5GD1w2HE8xM=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=

--- a/pkg/agent/dummy_data_gatherer.go
+++ b/pkg/agent/dummy_data_gatherer.go
@@ -40,10 +40,6 @@ func (g *dummyDataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
 }
 
-func (g *dummyDataGatherer) Equals(old datagatherer.DataGatherer) bool {
-	return false
-}
-
 func (c *dummyDataGatherer) Fetch() (interface{}, error) {
 	var err error
 	if c.attemptNumber < c.FailedAttempts {

--- a/pkg/agent/dummy_data_gatherer.go
+++ b/pkg/agent/dummy_data_gatherer.go
@@ -40,6 +40,10 @@ func (g *dummyDataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
 }
 
+func (g *dummyDataGatherer) Equals(old datagatherer.DataGatherer) bool {
+	return false
+}
+
 func (c *dummyDataGatherer) Fetch() (interface{}, error) {
 	var err error
 	if c.attemptNumber < c.FailedAttempts {

--- a/pkg/agent/dummy_data_gatherer.go
+++ b/pkg/agent/dummy_data_gatherer.go
@@ -40,6 +40,10 @@ func (g *dummyDataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
 }
 
+func (g *dummyDataGatherer) Delete() error {
+	return nil
+}
+
 func (c *dummyDataGatherer) Fetch() (interface{}, error) {
 	var err error
 	if c.attemptNumber < c.FailedAttempts {

--- a/pkg/agent/dummy_data_gatherer.go
+++ b/pkg/agent/dummy_data_gatherer.go
@@ -29,6 +29,17 @@ type dummyDataGatherer struct {
 	FailedAttempts int
 }
 
+// Run starts the data gatherer's informers for resource collection.
+// Returns error if the data gatherer informer wasn't initialized
+func (g *dummyDataGatherer) Run(stopCh <-chan struct{}) error {
+	return fmt.Errorf("data gatherer's informer was not initialized")
+}
+
+// WaitForCacheSync waits for the data gatherer's informers cache to sync.
+func (g *dummyDataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
+	return fmt.Errorf("timed out waiting for caches to sync")
+}
+
 func (c *dummyDataGatherer) Fetch() (interface{}, error) {
 	var err error
 	if c.attemptNumber < c.FailedAttempts {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -204,7 +204,14 @@ func gatherData(ctx context.Context, config Config) []*api.DataReading {
 		if err != nil {
 			log.Fatalf("failed to instantiate %s DataGatherer: %v", kind, err)
 		}
-
+		// start the data gatherers and wait for the cache sync
+		// TODO add backoff retry
+		if err := dg.Run(ctx.Done()); err != nil {
+			log.Printf("failed to start %s DataGatherer: %v", kind, err)
+		}
+		if err := dg.WaitForCacheSync(ctx.Done()); err != nil {
+			log.Printf("failed to cache sync %s DataGatherer: %v", kind, err)
+		}
 		dataGatherers[dgConfig.Name] = dg
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,6 +16,12 @@ var ClientID string
 var ClientSecret string
 var AuthServerDomain string
 
+// schema version of the data sent by the agent
+// default is v2. The agent sends data readings using
+// api.gathereredResources
+// v1. The agent sends data readings using unstructuredList
+const schemaVersion string = "v2"
+
 // PreflightClient can be used to talk to the Preflight backend.
 type PreflightClient struct {
 	// OAuth2
@@ -81,6 +87,7 @@ func (c *PreflightClient) PostDataReadings(orgID string, readings []*api.DataRea
 		AgentMetadata:  c.agentMetadata,
 		DataGatherTime: time.Now().UTC(),
 		DataReadings:   readings,
+		SchemaVersion:  schemaVersion,
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,11 +16,13 @@ var ClientID string
 var ClientSecret string
 var AuthServerDomain string
 
-// schema version of the data sent by the agent
-// default is v2. The agent sends data readings using
-// api.gathereredResources
-// v1. The agent sends data readings using unstructuredList
-const schemaVersion string = "v2"
+// schema version of the data sent by the agent.
+// The new default version is v2.
+// In v2 the agent posts data readings using api.gathereredResources
+// Any requests without a schema version set will be interpreted
+// as using v1 by the backend. In v1 the agent sends
+// raw resource data of unstructuredList
+const schemaVersion string = "v2.0.0"
 
 // PreflightClient can be used to talk to the Preflight backend.
 type PreflightClient struct {

--- a/pkg/datagatherer/aks/aks.go
+++ b/pkg/datagatherer/aks/aks.go
@@ -106,6 +106,17 @@ type Info struct {
 	Cluster *aks.ManagedCluster
 }
 
+// Run starts the data gatherer's informers for resource collection.
+// Returns error if the data gatherer informer wasn't initialized
+func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
+	return fmt.Errorf("data gatherer's informer was not initialized")
+}
+
+// WaitForCacheSync waits for the data gatherer's informers cache to sync.
+func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
+	return fmt.Errorf("timed out waiting for caches to sync")
+}
+
 // Fetch retrieves cluster information from AKS.
 func (g *DataGatherer) Fetch() (interface{}, error) {
 	client := &http.Client{}

--- a/pkg/datagatherer/aks/aks.go
+++ b/pkg/datagatherer/aks/aks.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"strings"
 
 	aks "github.com/Azure/aks-engine/pkg/api/agentPoolOnlyApi/v20180331"
@@ -116,14 +115,6 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
-}
-
-func (g *DataGatherer) Equals(old datagatherer.DataGatherer) bool {
-	dg, ok := old.(*DataGatherer)
-	if !ok {
-		return false
-	}
-	return !reflect.DeepEqual(g, dg)
 }
 
 // Fetch retrieves cluster information from AKS.

--- a/pkg/datagatherer/aks/aks.go
+++ b/pkg/datagatherer/aks/aks.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strings"
 
 	aks "github.com/Azure/aks-engine/pkg/api/agentPoolOnlyApi/v20180331"
@@ -115,6 +116,14 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
+}
+
+func (g *DataGatherer) Equals(old datagatherer.DataGatherer) bool {
+	dg, ok := old.(*DataGatherer)
+	if !ok {
+		return false
+	}
+	return !reflect.DeepEqual(g, dg)
 }
 
 // Fetch retrieves cluster information from AKS.

--- a/pkg/datagatherer/aks/aks.go
+++ b/pkg/datagatherer/aks/aks.go
@@ -112,6 +112,10 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 	return fmt.Errorf("data gatherer's informer was not initialized")
 }
 
+func (g *DataGatherer) Delete() error {
+	return nil
+}
+
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")

--- a/pkg/datagatherer/datagatherer.go
+++ b/pkg/datagatherer/datagatherer.go
@@ -18,6 +18,4 @@ type DataGatherer interface {
 	Run(stopCh <-chan struct{}) error
 	// WaitForCacheSync waits for the data gatherer's informers cache to sync.
 	WaitForCacheSync(stopCh <-chan struct{}) error
-	// Equals compares two data gatherers to check for shallow equality
-	Equals(old DataGatherer) bool
 }

--- a/pkg/datagatherer/datagatherer.go
+++ b/pkg/datagatherer/datagatherer.go
@@ -18,4 +18,6 @@ type DataGatherer interface {
 	Run(stopCh <-chan struct{}) error
 	// WaitForCacheSync waits for the data gatherer's informers cache to sync.
 	WaitForCacheSync(stopCh <-chan struct{}) error
+	// Equals compares two data gatherers to check for shallow equality
+	Equals(old DataGatherer) bool
 }

--- a/pkg/datagatherer/datagatherer.go
+++ b/pkg/datagatherer/datagatherer.go
@@ -18,4 +18,6 @@ type DataGatherer interface {
 	Run(stopCh <-chan struct{}) error
 	// WaitForCacheSync waits for the data gatherer's informers cache to sync.
 	WaitForCacheSync(stopCh <-chan struct{}) error
+	// Delete, free all resources used by the data gatherer
+	Delete() error
 }

--- a/pkg/datagatherer/datagatherer.go
+++ b/pkg/datagatherer/datagatherer.go
@@ -13,4 +13,9 @@ type Config interface {
 type DataGatherer interface {
 	// Fetch retrieves data.
 	Fetch() (interface{}, error)
+	// Run starts the data gatherer's informers for resource collection.
+	// Returns error if the data gatherer informer wasn't initialized
+	Run(stopCh <-chan struct{}) error
+	// WaitForCacheSync waits for the data gatherer's informers cache to sync.
+	WaitForCacheSync(stopCh <-chan struct{}) error
 }

--- a/pkg/datagatherer/eks/eks.go
+++ b/pkg/datagatherer/eks/eks.go
@@ -4,7 +4,6 @@ package eks
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -59,14 +58,6 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
-}
-
-func (g *DataGatherer) Equals(old datagatherer.DataGatherer) bool {
-	dg, ok := old.(*DataGatherer)
-	if !ok {
-		return false
-	}
-	return !reflect.DeepEqual(g, dg)
 }
 
 // Fetch retrieves cluster information from EKS.

--- a/pkg/datagatherer/eks/eks.go
+++ b/pkg/datagatherer/eks/eks.go
@@ -55,6 +55,10 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 	return fmt.Errorf("data gatherer's informer was not initialized")
 }
 
+func (g *DataGatherer) Delete() error {
+	return nil
+}
+
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")

--- a/pkg/datagatherer/eks/eks.go
+++ b/pkg/datagatherer/eks/eks.go
@@ -49,6 +49,17 @@ type Info struct {
 	Cluster *eks.Cluster
 }
 
+// Run starts the data gatherer's informers for resource collection.
+// Returns error if the data gatherer informer wasn't initialized
+func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
+	return fmt.Errorf("data gatherer's informer was not initialized")
+}
+
+// WaitForCacheSync waits for the data gatherer's informers cache to sync.
+func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
+	return fmt.Errorf("timed out waiting for caches to sync")
+}
+
 // Fetch retrieves cluster information from EKS.
 func (g *DataGatherer) Fetch() (interface{}, error) {
 	input := &eks.DescribeClusterInput{

--- a/pkg/datagatherer/eks/eks.go
+++ b/pkg/datagatherer/eks/eks.go
@@ -4,6 +4,7 @@ package eks
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -58,6 +59,14 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
+}
+
+func (g *DataGatherer) Equals(old datagatherer.DataGatherer) bool {
+	dg, ok := old.(*DataGatherer)
+	if !ok {
+		return false
+	}
+	return !reflect.DeepEqual(g, dg)
 }
 
 // Fetch retrieves cluster information from EKS.

--- a/pkg/datagatherer/gke/gke.go
+++ b/pkg/datagatherer/gke/gke.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"reflect"
 	"strings"
 
 	"github.com/jetstack/preflight/pkg/datagatherer"
@@ -95,14 +94,6 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
-}
-
-func (g *DataGatherer) Equals(old datagatherer.DataGatherer) bool {
-	dg, ok := old.(*DataGatherer)
-	if !ok {
-		return false
-	}
-	return !reflect.DeepEqual(g, dg)
 }
 
 // Fetch retrieves cluster information from GKE.

--- a/pkg/datagatherer/gke/gke.go
+++ b/pkg/datagatherer/gke/gke.go
@@ -91,6 +91,10 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 	return fmt.Errorf("data gatherer's informer was not initialized")
 }
 
+func (g *DataGatherer) Delete() error {
+	return nil
+}
+
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")

--- a/pkg/datagatherer/gke/gke.go
+++ b/pkg/datagatherer/gke/gke.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 
 	"github.com/jetstack/preflight/pkg/datagatherer"
@@ -94,6 +95,14 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
+}
+
+func (g *DataGatherer) Equals(old datagatherer.DataGatherer) bool {
+	dg, ok := old.(*DataGatherer)
+	if !ok {
+		return false
+	}
+	return !reflect.DeepEqual(g, dg)
 }
 
 // Fetch retrieves cluster information from GKE.

--- a/pkg/datagatherer/gke/gke.go
+++ b/pkg/datagatherer/gke/gke.go
@@ -85,6 +85,17 @@ func (c *Config) NewDataGatherer(ctx context.Context) (datagatherer.DataGatherer
 	}, nil
 }
 
+// Run starts the data gatherer's informers for resource collection.
+// Returns error if the data gatherer informer wasn't initialized
+func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
+	return fmt.Errorf("data gatherer's informer was not initialized")
+}
+
+// WaitForCacheSync waits for the data gatherer's informers cache to sync.
+func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
+	return fmt.Errorf("timed out waiting for caches to sync")
+}
+
 // Fetch retrieves cluster information from GKE.
 func (g *DataGatherer) Fetch() (interface{}, error) {
 	var credsOpt option.ClientOption

--- a/pkg/datagatherer/istio/istio.go
+++ b/pkg/datagatherer/istio/istio.go
@@ -125,6 +125,16 @@ func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return nil
 }
 
+func (g *DataGatherer) Delete() error {
+	for _, dynamicDg := range g.dynamicDataGatherers {
+		err := dynamicDg.Delete()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Fetch retrieves resources from the K8s API and runs Istio analysis.
 func (g *DataGatherer) Fetch() (interface{}, error) {
 

--- a/pkg/datagatherer/istio/istio.go
+++ b/pkg/datagatherer/istio/istio.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"gopkg.in/yaml.v2"
-	"reflect"
 	"strings"
 	"time"
 
@@ -124,29 +123,6 @@ func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 		}
 	}
 	return nil
-}
-
-func (g *DataGatherer) Equals(old datagatherer.DataGatherer) bool {
-	// shallow equality
-	dg, ok := old.(*DataGatherer)
-	if !ok {
-		return false
-	}
-
-	if !reflect.DeepEqual(g.sourceAnalyzer, dg.sourceAnalyzer) {
-		return false
-	}
-	if len(g.dynamicDataGatherers) != len(dg.dynamicDataGatherers) {
-		return false
-	}
-
-	for i := range g.dynamicDataGatherers {
-		if !g.dynamicDataGatherers[i].Equals(dg.dynamicDataGatherers[i]) {
-			return false
-		}
-	}
-
-	return true
 }
 
 // Fetch retrieves resources from the K8s API and runs Istio analysis.

--- a/pkg/datagatherer/istio/istio_test.go
+++ b/pkg/datagatherer/istio/istio_test.go
@@ -38,7 +38,7 @@ func TestFetch(t *testing.T) {
 	}
 	defer os.Remove(kubeConfigPath)
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	// Create the Config for the test.
 	config := Config{}
 	err = yaml.Unmarshal([]byte(fmt.Sprintf(configString, kubeConfigPath)), &config)

--- a/pkg/datagatherer/istio/istio_test.go
+++ b/pkg/datagatherer/istio/istio_test.go
@@ -167,36 +167,40 @@ func createLocalTestServer(t *testing.T) *httptest.Server {
 
 var watchString = `
 {
-	"type": "ADDED",
-	"object": {
-	  "kind": "Namespace",
-	  "apiVersion": "v1",
-	  "metadata": {
-		"name": "default"
-	  },
-	  "spec": {
-	  },
-	  "status": {
-		"phase": "Active"
-	  }
-	}
-}`
+    "type":"ADDED",
+    "object":{
+        "kind":"Namespace",
+        "apiVersion":"v1",
+        "metadata":{
+            "name":"default",
+            "uid":"d966826d-e63c-487c-a769-cb02098b95fd"
+        },
+        "spec":{
+            
+        },
+        "status":{
+            "phase":"Active"
+        }
+    }
+}
+`
 var testNamespaces = `
 {
-  "apiVersion": "v1",
-  "items": [
-    {
-      "apiVersion": "v1",
-      "kind": "Namespace",
-      "metadata": {
-        "name": "default"
-      }
+    "apiVersion":"v1",
+    "items":[
+        {
+            "apiVersion":"v1",
+            "kind":"Namespace",
+            "metadata":{
+                "name":"default",
+                "uid":"d966826d-e63c-487c-a769-cb02098b95fd"
+            }
+        }
+    ],
+    "kind":"List",
+    "metadata":{
+        "resourceVersion":"",
+        "selfLink":""
     }
-  ],
-  "kind": "List",
-  "metadata": {
-    "resourceVersion": "",
-    "selfLink": ""
-  }
 }
 `

--- a/pkg/datagatherer/istio/istio_test.go
+++ b/pkg/datagatherer/istio/istio_test.go
@@ -141,10 +141,20 @@ func createLocalTestServer(t *testing.T) *httptest.Server {
 	var localServer *httptest.Server
 	localServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var responseContent []byte
+		params := r.URL.Query()
+		isWatch := true
+		if params.Get("watch") == "" {
+			isWatch = false
+		}
 
 		switch r.URL.Path {
 		case "/api/v1/namespaces":
-			responseContent = []byte(testNamespaces)
+			if isWatch {
+				responseContent = []byte(watchString)
+			} else {
+				responseContent = []byte(testNamespaces)
+			}
+			w.Header().Set("Content-Type", "application/json")
 		default:
 			t.Fatalf("Unexpected URL was called: %s", r.URL.Path)
 		}
@@ -155,6 +165,22 @@ func createLocalTestServer(t *testing.T) *httptest.Server {
 	return localServer
 }
 
+var watchString = `
+{
+	"type": "ADDED",
+	"object": {
+	  "kind": "Namespace",
+	  "apiVersion": "v1",
+	  "metadata": {
+		"name": "default"
+	  },
+	  "spec": {
+	  },
+	  "status": {
+		"phase": "Active"
+	  }
+	}
+}`
 var testNamespaces = `
 {
   "apiVersion": "v1",

--- a/pkg/datagatherer/k8s/cache.go
+++ b/pkg/datagatherer/k8s/cache.go
@@ -32,8 +32,7 @@ func onAdd(obj interface{}, dgCache *cache.Cache) {
 		data := metadata.(map[string]interface{})
 		if uid, ok := data["uid"]; ok {
 			cacheObject := &api.GatheredResource{
-				Resource:   obj,
-				Properties: &api.GatheredResourceMetadata{},
+				Resource: obj,
 			}
 			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
 		} else {
@@ -71,7 +70,7 @@ func onDelete(obj interface{}, dgCache *cache.Cache) {
 		data := metadata.(map[string]interface{})
 		if uid, ok := data["uid"]; ok {
 			cacheObject := updateCacheGatheredResource(uid.(string), obj, dgCache)
-			cacheObject.Properties.DeletedAt = &api.Time{Time: clock.now()}
+			cacheObject.DeletedAt = &api.Time{Time: clock.now()}
 			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
 		} else {
 			log.Printf("could not %q resource %q to the cache, missing uid field", "delete", data["name"].(string))
@@ -88,14 +87,13 @@ func updateCacheGatheredResource(cacheKey string, resource interface{},
 	dgCache *cache.Cache) *api.GatheredResource {
 	// updated cache object
 	cacheObject := &api.GatheredResource{
-		Resource:   resource,
-		Properties: &api.GatheredResourceMetadata{},
+		Resource: resource,
 	}
 	// update the object's properties, if it's already in the cache
 	if o, ok := dgCache.Get(cacheKey); ok {
-		cachedProperties := o.(*api.GatheredResource).Properties
-		if cachedProperties != nil {
-			cacheObject.Properties = cachedProperties
+		deletedAt := o.(*api.GatheredResource).DeletedAt
+		if deletedAt != nil {
+			cacheObject.DeletedAt = deletedAt
 		}
 	}
 	return cacheObject

--- a/pkg/datagatherer/k8s/cache.go
+++ b/pkg/datagatherer/k8s/cache.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"log"
 	"time"
 
 	"github.com/jetstack/preflight/api"
@@ -35,7 +36,11 @@ func onAdd(obj interface{}, dgCache *cache.Cache) {
 				Properties: &api.GatheredResourceMetadata{},
 			}
 			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
+		} else {
+			log.Printf("could not %q resource %q to the cache, missing uid field", "add", data["name"].(string))
 		}
+	} else {
+		log.Printf("could not %q resource to the cache, missing metadata", "add")
 	}
 }
 
@@ -49,7 +54,11 @@ func onUpdate(old, new interface{}, dgCache *cache.Cache) {
 		if uid, ok := data["uid"]; ok {
 			cacheObject := updateCacheGatheredResource(uid.(string), new, dgCache)
 			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
+		} else {
+			log.Printf("could not %q resource %q to the cache, missing uid field", "update", data["name"].(string))
 		}
+	} else {
+		log.Printf("could not %q resource to the cache, missing metadata", "update")
 	}
 }
 
@@ -64,7 +73,11 @@ func onDelete(obj interface{}, dgCache *cache.Cache) {
 			cacheObject := updateCacheGatheredResource(uid.(string), obj, dgCache)
 			cacheObject.Properties.DeletedAt = &api.Time{Time: clock.now()}
 			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
+		} else {
+			log.Printf("could not %q resource %q to the cache, missing uid field", "delete", data["name"].(string))
 		}
+	} else {
+		log.Printf("could not %q resource to the cache, missing metadata", "delete")
 	}
 }
 

--- a/pkg/datagatherer/k8s/cache.go
+++ b/pkg/datagatherer/k8s/cache.go
@@ -1,0 +1,76 @@
+package k8s
+
+import (
+	"time"
+
+	"github.com/jetstack/preflight/api"
+	"github.com/pmylund/go-cache"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type timeInterface interface {
+	now() time.Time
+}
+
+var clock timeInterface = &realTime{}
+
+type realTime struct {
+}
+
+func (*realTime) now() time.Time {
+	return time.Now()
+}
+
+func onAdd(obj interface{}, dgCache *cache.Cache) {
+	item := obj.(*unstructured.Unstructured)
+	if metadata, ok := item.Object["metadata"]; ok {
+		data := metadata.(map[string]interface{})
+		if uid, ok := data["uid"]; ok {
+			cacheObject := &api.GatheredResource{
+				Resource:   obj,
+				Properties: &api.GatheredResourceMetadata{},
+			}
+			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
+		}
+	}
+}
+
+func onUpdate(old, new interface{}, dgCache *cache.Cache) {
+	item := old.(*unstructured.Unstructured)
+	if metadata, ok := item.Object["metadata"]; ok {
+		data := metadata.(map[string]interface{})
+		if uid, ok := data["uid"]; ok {
+			cacheObject := updateCacheGatheredResource(uid.(string), new, dgCache)
+			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
+		}
+	}
+}
+
+func onDelete(obj interface{}, dgCache *cache.Cache) {
+	item := obj.(*unstructured.Unstructured)
+	if metadata, ok := item.Object["metadata"]; ok {
+		data := metadata.(map[string]interface{})
+		if uid, ok := data["uid"]; ok {
+			cacheObject := updateCacheGatheredResource(uid.(string), obj, dgCache)
+			cacheObject.Properties.DeletedAt = &api.Time{Time: clock.now()}
+			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
+		}
+	}
+}
+
+func updateCacheGatheredResource(cacheKey string, resource interface{},
+	dgCache *cache.Cache) *api.GatheredResource {
+	// updated cache object
+	cacheObject := &api.GatheredResource{
+		Resource:   resource,
+		Properties: &api.GatheredResourceMetadata{},
+	}
+	// update the object's properties, if it's already in the cache
+	if o, ok := dgCache.Get(cacheKey); ok {
+		cachedProperties := o.(*api.GatheredResource).Properties
+		if cachedProperties != nil {
+			cacheObject.Properties = cachedProperties
+		}
+	}
+	return cacheObject
+}

--- a/pkg/datagatherer/k8s/cache.go
+++ b/pkg/datagatherer/k8s/cache.go
@@ -8,6 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// time interface, this is used to fetch the current time
+// whenever a k8s resource is deleted
 type timeInterface interface {
 	now() time.Time
 }
@@ -21,6 +23,8 @@ func (*realTime) now() time.Time {
 	return time.Now()
 }
 
+// onAdd handles the informer creation events, adding the created runtime.Object
+// to the data gatherer's cache. The cache key is the uid of the object
 func onAdd(obj interface{}, dgCache *cache.Cache) {
 	item := obj.(*unstructured.Unstructured)
 	if metadata, ok := item.Object["metadata"]; ok {
@@ -35,6 +39,9 @@ func onAdd(obj interface{}, dgCache *cache.Cache) {
 	}
 }
 
+// onUpdate handles the informer update events, replacing the old object with the new one
+// if it's present in the data gatherer's cache, (if the object isn't present, it gets added).
+// The cache key is the uid of the object
 func onUpdate(old, new interface{}, dgCache *cache.Cache) {
 	item := old.(*unstructured.Unstructured)
 	if metadata, ok := item.Object["metadata"]; ok {
@@ -46,6 +53,9 @@ func onUpdate(old, new interface{}, dgCache *cache.Cache) {
 	}
 }
 
+// onDelete handles the informer deletion events, updating the object's properties with the deletion
+// time of the object (but not removing the object from the cache).
+// The cache key is the uid of the object
 func onDelete(obj interface{}, dgCache *cache.Cache) {
 	item := obj.(*unstructured.Unstructured)
 	if metadata, ok := item.Object["metadata"]; ok {
@@ -58,6 +68,9 @@ func onDelete(obj interface{}, dgCache *cache.Cache) {
 	}
 }
 
+// creates a new updated instance of a cache object, with the resource
+// argument. If the object is present in the cache it fetches the object's
+// properties.
 func updateCacheGatheredResource(cacheKey string, resource interface{},
 	dgCache *cache.Cache) *api.GatheredResource {
 	// updated cache object

--- a/pkg/datagatherer/k8s/cache_test.go
+++ b/pkg/datagatherer/k8s/cache_test.go
@@ -1,0 +1,128 @@
+package k8s
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/d4l3k/messagediff"
+	"github.com/jetstack/preflight/api"
+	"github.com/pmylund/go-cache"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func makeGatheredResource(obj runtime.Object, data *api.GatheredResourceMetadata) *api.GatheredResource {
+	return &api.GatheredResource{
+		Resource:   obj,
+		Properties: data,
+	}
+}
+
+func TestOnAddCache(t *testing.T) {
+	tcs := map[string]struct {
+		inputObjects []runtime.Object
+		eventObjects []runtime.Object
+		eventFunc    func(old, obj interface{}, dgCache *cache.Cache)
+		expected     []*api.GatheredResource
+	}{
+		"add all objects": {
+			inputObjects: []runtime.Object{
+				getObject("foobar/v1", "Foo", "testfoo", "testns", false),
+				getObject("v1", "Service", "testservice", "testns", false),
+				getObject("foobar/v1", "NotFoo", "notfoo", "testns", false),
+			},
+			expected: []*api.GatheredResource{
+				makeGatheredResource(getObject("foobar/v1", "Foo", "testfoo", "testns", false), &api.GatheredResourceMetadata{}),
+				makeGatheredResource(getObject("v1", "Service", "testservice", "testns", false), &api.GatheredResourceMetadata{}),
+				makeGatheredResource(getObject("foobar/v1", "NotFoo", "notfoo", "testns", false), &api.GatheredResourceMetadata{}),
+			},
+		},
+		"delete all objects. All objects should have the deletedAt flag": {
+			inputObjects: []runtime.Object{
+				getObject("foobar/v1", "Foo", "testfoo", "testns", false),
+				getObject("v1", "Service", "testservice", "testns", false),
+				getObject("foobar/v1", "NotFoo", "notfoo", "testns", false),
+			},
+			// objects to delete
+			eventObjects: []runtime.Object{
+				getObject("foobar/v1", "Foo", "testfoo", "testns", false),
+				getObject("v1", "Service", "testservice", "testns", false),
+				getObject("foobar/v1", "NotFoo", "notfoo", "testns", false),
+			},
+			eventFunc: func(old, new interface{}, dgCache *cache.Cache) { onDelete(old, dgCache) },
+			expected: []*api.GatheredResource{
+				makeGatheredResource(getObject("foobar/v1", "Foo", "testfoo", "testns", false),
+					&api.GatheredResourceMetadata{
+						DeletedAt: &api.Time{Time: clock.now()},
+					}),
+				makeGatheredResource(getObject("v1", "Service", "testservice", "testns", false),
+					&api.GatheredResourceMetadata{
+						DeletedAt: &api.Time{Time: clock.now()},
+					}),
+				makeGatheredResource(getObject("foobar/v1", "NotFoo", "notfoo", "testns", false),
+					&api.GatheredResourceMetadata{
+						DeletedAt: &api.Time{Time: clock.now()},
+					}),
+			},
+		},
+		"update all objects' namespace": {
+			inputObjects: []runtime.Object{
+				getObject("foobar/v1", "Foo", "testfoo", "testns", false),
+				getObject("v1", "Service", "testservice", "testns", false),
+				getObject("foobar/v1", "NotFoo", "notfoo", "testns", false),
+			},
+			// objects to update
+			eventObjects: []runtime.Object{
+				getObject("foobar/v1", "Foo", "testfoo", "testns1", false),
+				getObject("v1", "Service", "testservice", "testns1", false),
+				getObject("foobar/v1", "NotFoo", "notfoo", "testns1", false),
+			},
+			eventFunc: onUpdate,
+			expected: []*api.GatheredResource{
+				makeGatheredResource(getObject("foobar/v1", "Foo", "testfoo", "testns1", false), &api.GatheredResourceMetadata{}),
+				makeGatheredResource(getObject("v1", "Service", "testservice", "testns1", false), &api.GatheredResourceMetadata{}),
+				makeGatheredResource(getObject("foobar/v1", "NotFoo", "notfoo", "testns1", false), &api.GatheredResourceMetadata{}),
+			},
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			dgCache := cache.New(5*time.Minute, 30*time.Second)
+			// adding initial objetcs to the cache
+			for _, obj := range tc.inputObjects {
+				onAdd(obj, dgCache)
+			}
+
+			// Testing event founction on set of objects
+			for _, obj := range tc.eventObjects {
+				if tc.eventFunc != nil {
+					tc.eventFunc(obj, obj, dgCache)
+				}
+			}
+
+			// items back from the cache
+			list := []*api.GatheredResource{}
+			for _, item := range dgCache.Items() {
+				cacheObject := item.Object.(*api.GatheredResource)
+				list = append(list, cacheObject)
+			}
+
+			// sorting list of results by name
+			sortGatheredResources(list)
+			// sorting list of expected results by name
+			sortGatheredResources(tc.expected)
+
+			if len(list) != len(tc.expected) {
+				t.Errorf("unexpected number of return items found. exp:%+v act:%+v", tc.expected, list)
+			}
+
+			if diff, equal := messagediff.PrettyDiff(tc.expected, list); !equal {
+				t.Errorf("\n%s", diff)
+				expectedJSON, _ := json.MarshalIndent(tc.expected, "", "  ")
+				gotJSON, _ := json.MarshalIndent(list, "", "  ")
+				t.Fatalf("unexpected JSON: \ngot \n%s\nwant\n%s", string(gotJSON), expectedJSON)
+			}
+		})
+	}
+}

--- a/pkg/datagatherer/k8s/cache_test.go
+++ b/pkg/datagatherer/k8s/cache_test.go
@@ -11,10 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func makeGatheredResource(obj runtime.Object, data *api.GatheredResourceMetadata) *api.GatheredResource {
+func makeGatheredResource(obj runtime.Object, deletedAt *api.Time) *api.GatheredResource {
 	return &api.GatheredResource{
-		Resource:   obj,
-		Properties: data,
+		Resource:  obj,
+		DeletedAt: deletedAt,
 	}
 }
 
@@ -32,9 +32,9 @@ func TestOnAddCache(t *testing.T) {
 				getObject("foobar/v1", "NotFoo", "notfoo", "testns", false),
 			},
 			expected: []*api.GatheredResource{
-				makeGatheredResource(getObject("foobar/v1", "Foo", "testfoo", "testns", false), &api.GatheredResourceMetadata{}),
-				makeGatheredResource(getObject("v1", "Service", "testservice", "testns", false), &api.GatheredResourceMetadata{}),
-				makeGatheredResource(getObject("foobar/v1", "NotFoo", "notfoo", "testns", false), &api.GatheredResourceMetadata{}),
+				makeGatheredResource(getObject("foobar/v1", "Foo", "testfoo", "testns", false), nil),
+				makeGatheredResource(getObject("v1", "Service", "testservice", "testns", false), nil),
+				makeGatheredResource(getObject("foobar/v1", "NotFoo", "notfoo", "testns", false), nil),
 			},
 		},
 		"delete all objects. All objects should have the deletedAt flag": {
@@ -52,17 +52,14 @@ func TestOnAddCache(t *testing.T) {
 			eventFunc: func(old, new interface{}, dgCache *cache.Cache) { onDelete(old, dgCache) },
 			expected: []*api.GatheredResource{
 				makeGatheredResource(getObject("foobar/v1", "Foo", "testfoo", "testns", false),
-					&api.GatheredResourceMetadata{
-						DeletedAt: &api.Time{Time: clock.now()},
-					}),
+					&api.Time{Time: clock.now()},
+				),
 				makeGatheredResource(getObject("v1", "Service", "testservice", "testns", false),
-					&api.GatheredResourceMetadata{
-						DeletedAt: &api.Time{Time: clock.now()},
-					}),
+					&api.Time{Time: clock.now()},
+				),
 				makeGatheredResource(getObject("foobar/v1", "NotFoo", "notfoo", "testns", false),
-					&api.GatheredResourceMetadata{
-						DeletedAt: &api.Time{Time: clock.now()},
-					}),
+					&api.Time{Time: clock.now()},
+				),
 			},
 		},
 		"update all objects' namespace": {
@@ -79,9 +76,9 @@ func TestOnAddCache(t *testing.T) {
 			},
 			eventFunc: onUpdate,
 			expected: []*api.GatheredResource{
-				makeGatheredResource(getObject("foobar/v1", "Foo", "testfoo", "testns1", false), &api.GatheredResourceMetadata{}),
-				makeGatheredResource(getObject("v1", "Service", "testservice", "testns1", false), &api.GatheredResourceMetadata{}),
-				makeGatheredResource(getObject("foobar/v1", "NotFoo", "notfoo", "testns1", false), &api.GatheredResourceMetadata{}),
+				makeGatheredResource(getObject("foobar/v1", "Foo", "testfoo", "testns1", false), nil),
+				makeGatheredResource(getObject("v1", "Service", "testservice", "testns1", false), nil),
+				makeGatheredResource(getObject("foobar/v1", "NotFoo", "notfoo", "testns1", false), nil),
 			},
 		},
 	}

--- a/pkg/datagatherer/k8s/discovery.go
+++ b/pkg/datagatherer/k8s/discovery.go
@@ -46,6 +46,17 @@ type DataGathererDiscovery struct {
 	cl discovery.DiscoveryClient
 }
 
+// Run starts the data gatherer's informers for resource collection.
+// Returns error if the data gatherer informer wasn't initialized
+func (g *DataGathererDiscovery) Run(stopCh <-chan struct{}) error {
+	return fmt.Errorf("data gatherer's informer was not initialized")
+}
+
+// WaitForCacheSync waits for the data gatherer's informers cache to sync.
+func (g *DataGathererDiscovery) WaitForCacheSync(stopCh <-chan struct{}) error {
+	return fmt.Errorf("timed out waiting for caches to sync")
+}
+
 // Fetch will fetch discovery data from the apiserver, or return an error
 func (g *DataGathererDiscovery) Fetch() (interface{}, error) {
 	data, err := g.cl.ServerVersion()

--- a/pkg/datagatherer/k8s/discovery.go
+++ b/pkg/datagatherer/k8s/discovery.go
@@ -49,12 +49,20 @@ type DataGathererDiscovery struct {
 // Run starts the data gatherer's informers for resource collection.
 // Returns error if the data gatherer informer wasn't initialized
 func (g *DataGathererDiscovery) Run(stopCh <-chan struct{}) error {
-	return fmt.Errorf("data gatherer's informer was not initialized")
+	// discovery doesn't use informers underneat
+	// fmt.Errorf("data gatherer's informer was not initialized")
+	return nil
 }
 
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGathererDiscovery) WaitForCacheSync(stopCh <-chan struct{}) error {
-	return fmt.Errorf("timed out waiting for caches to sync")
+	// discovery doesn't use informers underneat
+	// fmt.Errorf("timed out waiting for caches to sync")
+	return nil
+}
+
+func (g *DataGathererDiscovery) Delete() error {
+	return nil
 }
 
 // Fetch will fetch discovery data from the apiserver, or return an error

--- a/pkg/datagatherer/k8s/discovery.go
+++ b/pkg/datagatherer/k8s/discovery.go
@@ -57,10 +57,6 @@ func (g *DataGathererDiscovery) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
 }
 
-func (g *DataGathererDiscovery) Equals(old datagatherer.DataGatherer) bool {
-	return false
-}
-
 // Fetch will fetch discovery data from the apiserver, or return an error
 func (g *DataGathererDiscovery) Fetch() (interface{}, error) {
 	data, err := g.cl.ServerVersion()

--- a/pkg/datagatherer/k8s/discovery.go
+++ b/pkg/datagatherer/k8s/discovery.go
@@ -57,6 +57,10 @@ func (g *DataGathererDiscovery) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
 }
 
+func (g *DataGathererDiscovery) Equals(old datagatherer.DataGatherer) bool {
+	return false
+}
+
 // Fetch will fetch discovery data from the apiserver, or return an error
 func (g *DataGathererDiscovery) Fetch() (interface{}, error) {
 	data, err := g.cl.ServerVersion()

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -154,13 +154,21 @@ type DataGathererDynamic struct {
 	sharedInformer dynamicinformer.DynamicSharedInformerFactory
 }
 
-func (g *DataGathererDynamic) Run(stopCh <-chan struct{}) {
+// Run starts the dynamic data gatherer's informers for resource collection.
+// Returns error if the data gatherer informer wasn't initialized
+func (g *DataGathererDynamic) Run(stopCh <-chan struct{}) error {
+	if g.sharedInformer == nil {
+		return fmt.Errorf("data gatherer informer was not initialized")
+	}
+	// start shared informer
 	g.sharedInformer.Start(stopCh)
+	return nil
 }
 
+// WaitForCacheSync waits for the data gatherer's informers cache to sync before collecting the resources.
 func (g *DataGathererDynamic) WaitForCacheSync(stopCh <-chan struct{}) error {
 	if !k8scache.WaitForCacheSync(stopCh, g.informer.HasSynced) {
-		return fmt.Errorf("Timed out waiting for caches to sync")
+		return fmt.Errorf("timed out waiting for caches to sync")
 	}
 	return nil
 }

--- a/pkg/datagatherer/k8s/dynamic_test.go
+++ b/pkg/datagatherer/k8s/dynamic_test.go
@@ -511,7 +511,7 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 
 			// start data gatherer informer
 			dynamiDg := dg.(*DataGathererDynamic)
-			go dynamiDg.Run(ctx.Done())
+			dynamiDg.Run(ctx.Done())
 			err = dynamiDg.WaitForCacheSync(ctx.Done())
 			if err != nil {
 				t.Fatalf("unexpected client error: %+v", err)

--- a/pkg/datagatherer/k8s/dynamic_test.go
+++ b/pkg/datagatherer/k8s/dynamic_test.go
@@ -120,8 +120,28 @@ func TestNewDataGathererWithClient(t *testing.T) {
 		namespaces: config.IncludeNamespaces,
 	}
 
-	if !reflect.DeepEqual(dg, expected) {
-		t.Errorf("unexpected difference: %v", diff.ObjectDiff(dg, expected))
+	gatherer := dg.(*DataGathererDynamic)
+	// test gatherer's fields
+	if !reflect.DeepEqual(gatherer.ctx, expected.ctx) {
+		t.Errorf("unexpected ctx difference: %v", diff.ObjectDiff(dg, expected))
+	}
+	if !reflect.DeepEqual(gatherer.cl, expected.cl) {
+		t.Errorf("unexpected client difference: %v", diff.ObjectDiff(dg, expected))
+	}
+	if !reflect.DeepEqual(gatherer.groupVersionResource, expected.groupVersionResource) {
+		t.Errorf("unexpected gvr difference: %v", diff.ObjectDiff(dg, expected))
+	}
+	if !reflect.DeepEqual(gatherer.namespaces, expected.namespaces) {
+		t.Errorf("unexpected namespace difference: %v", diff.ObjectDiff(dg, expected))
+	}
+	if gatherer.cache == nil {
+		t.Errorf("unexpected cache value: %v", nil)
+	}
+	if gatherer.informer == nil {
+		t.Errorf("unexpected resource informer value: %v", nil)
+	}
+	if gatherer.sharedInformer == nil {
+		t.Errorf("unexpected sharedInformer value: %v", nil)
 	}
 }
 

--- a/pkg/datagatherer/k8s/dynamic_test.go
+++ b/pkg/datagatherer/k8s/dynamic_test.go
@@ -510,8 +510,11 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			k8scache.WaitForCacheSync(ctx.Done(), testInformer.HasSynced)
 
 			// start data gatherer informer
-			dynamiDg := dg.(*DataGathererDynamic)
-			dynamiDg.Run(ctx.Done())
+			dynamiDg := dg
+			err = dynamiDg.Run(ctx.Done())
+			if err != nil {
+				t.Fatalf("unexpected client error: %+v", err)
+			}
 			err = dynamiDg.WaitForCacheSync(ctx.Done())
 			if err != nil {
 				t.Fatalf("unexpected client error: %+v", err)

--- a/pkg/datagatherer/k8s/dynamic_test.go
+++ b/pkg/datagatherer/k8s/dynamic_test.go
@@ -310,7 +310,6 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 							},
 						},
 					},
-					Properties: &api.GatheredResourceMetadata{},
 				},
 			},
 		},
@@ -326,8 +325,7 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			},
 			expected: []*api.GatheredResource{
 				{
-					Resource:   getObject("foobar/v1", "Foo", "testfoo", "testns", false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getObject("foobar/v1", "Foo", "testfoo", "testns", false),
 				},
 			},
 		},
@@ -346,10 +344,8 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			},
 			expected: []*api.GatheredResource{
 				{
-					Resource: getObject("foobar/v1", "Foo", "testfoo", "testns", false),
-					Properties: &api.GatheredResourceMetadata{
-						DeletedAt: &api.Time{Time: clock.now()},
-					},
+					Resource:  getObject("foobar/v1", "Foo", "testfoo", "testns", false),
+					DeletedAt: &api.Time{Time: clock.now()},
 				},
 			},
 		},
@@ -364,8 +360,7 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			},
 			expected: []*api.GatheredResource{
 				{
-					Resource:   getObject("foobar/v1", "Foo", "testfoo", "testns", false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getObject("foobar/v1", "Foo", "testfoo", "testns", false),
 				},
 			},
 		},
@@ -380,12 +375,10 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			},
 			expected: []*api.GatheredResource{
 				{
-					Resource:   getObject("foobar/v1", "Foo", "testfoo1", "testns1", false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getObject("foobar/v1", "Foo", "testfoo1", "testns1", false),
 				},
 				{
-					Resource:   getObject("foobar/v1", "Foo", "testfoo2", "testns2", false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getObject("foobar/v1", "Foo", "testfoo2", "testns2", false),
 				},
 			},
 		},
@@ -400,12 +393,10 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			},
 			expected: []*api.GatheredResource{
 				{
-					Resource:   getObject("foobar/v1", "Foo", "testfoo1", "testns1", false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getObject("foobar/v1", "Foo", "testfoo1", "testns1", false),
 				},
 				{
-					Resource:   getObject("foobar/v1", "Foo", "testfoo2", "testns2", false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getObject("foobar/v1", "Foo", "testfoo2", "testns2", false),
 				},
 			},
 		},
@@ -424,16 +415,12 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			},
 			expected: []*api.GatheredResource{
 				{
-					Resource: getObject("foobar/v1", "Foo", "testfoo1", "testns1", false),
-					Properties: &api.GatheredResourceMetadata{
-						DeletedAt: &api.Time{Time: clock.now()},
-					},
+					Resource:  getObject("foobar/v1", "Foo", "testfoo1", "testns1", false),
+					DeletedAt: &api.Time{Time: clock.now()},
 				},
 				{
-					Resource: getObject("foobar/v1", "Foo", "testfoo2", "testns2", false),
-					Properties: &api.GatheredResourceMetadata{
-						DeletedAt: &api.Time{Time: clock.now()},
-					},
+					Resource:  getObject("foobar/v1", "Foo", "testfoo2", "testns2", false),
+					DeletedAt: &api.Time{Time: clock.now()},
 				},
 			},
 		},
@@ -452,12 +439,10 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			},
 			expected: []*api.GatheredResource{
 				{
-					Resource:   getObject("foobar/v1", "Foo", "testfoo1", "testns1", false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getObject("foobar/v1", "Foo", "testfoo1", "testns1", false),
 				},
 				{
-					Resource:   getObject("foobar/v1", "Foo", "testfoo2", "testns2", false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getObject("foobar/v1", "Foo", "testfoo2", "testns2", false),
 				},
 			},
 		},
@@ -476,12 +461,10 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			},
 			expected: []*api.GatheredResource{
 				{
-					Resource:   getSecret("testsecret", "testns1", nil, false, false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getSecret("testsecret", "testns1", nil, false, false),
 				},
 				{
-					Resource:   getSecret("anothertestsecret", "testns2", nil, false, false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getSecret("anothertestsecret", "testns2", nil, false, false),
 				},
 			},
 		},
@@ -508,12 +491,10 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 						"tls.crt": "value",
 						"ca.crt":  "value",
 					}, true, false),
-					Properties: &api.GatheredResourceMetadata{},
 				},
 				{
 					// all other keys removed
-					Resource:   getSecret("anothertestsecret", "testns2", nil, true, false),
-					Properties: &api.GatheredResourceMetadata{},
+					Resource: getSecret("anothertestsecret", "testns2", nil, true, false),
 				},
 			},
 		},
@@ -544,10 +525,12 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			testInformer := resourceInformer.Informer()
 			testInformer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
 				DeleteFunc: func(obj interface{}) {
-					wg.Done()
+					defer wg.Done()
+					time.Sleep(100 * time.Millisecond)
 				},
 				UpdateFunc: func(old, new interface{}) {
-					wg.Done()
+					defer wg.Done()
+					time.Sleep(100 * time.Millisecond)
 				},
 			})
 			//start test Informer
@@ -600,9 +583,14 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			}
 
 			if tc.expected != nil {
-				list, ok := res.([]*api.GatheredResource)
+				items, ok := res.(map[string]interface{})
 				if !ok {
-					t.Errorf("expected result be an *api.GatheredResource but wasn't")
+					t.Errorf("expected result be an map[string]interface{} but wasn't")
+				}
+
+				list, ok := items["items"].([]*api.GatheredResource)
+				if !ok {
+					t.Errorf("expected result be an []*api.GatheredResource but wasn't")
 				}
 				// sorting list of results by name
 				sortGatheredResources(list)

--- a/pkg/datagatherer/local/local.go
+++ b/pkg/datagatherer/local/local.go
@@ -38,6 +38,17 @@ func (c *Config) NewDataGatherer(ctx context.Context) (datagatherer.DataGatherer
 	}, nil
 }
 
+// Run starts the data gatherer's informers for resource collection.
+// Returns error if the data gatherer informer wasn't initialized
+func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
+	return fmt.Errorf("data gatherer's informer was not initialized")
+}
+
+// WaitForCacheSync waits for the data gatherer's informers cache to sync.
+func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
+	return fmt.Errorf("timed out waiting for caches to sync")
+}
+
 // Fetch loads and returns the data from the LocalDatagatherer's dataPath
 func (g *DataGatherer) Fetch() (interface{}, error) {
 	dataBytes, err := ioutil.ReadFile(g.dataPath)

--- a/pkg/datagatherer/local/local.go
+++ b/pkg/datagatherer/local/local.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"reflect"
 
 	"github.com/jetstack/preflight/pkg/datagatherer"
 )
@@ -48,14 +47,6 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
-}
-
-func (g *DataGatherer) Equals(old datagatherer.DataGatherer) bool {
-	dg, ok := old.(*DataGatherer)
-	if !ok {
-		return false
-	}
-	return !reflect.DeepEqual(g, dg)
 }
 
 // Fetch loads and returns the data from the LocalDatagatherer's dataPath

--- a/pkg/datagatherer/local/local.go
+++ b/pkg/datagatherer/local/local.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 
 	"github.com/jetstack/preflight/pkg/datagatherer"
 )
@@ -47,6 +48,14 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")
+}
+
+func (g *DataGatherer) Equals(old datagatherer.DataGatherer) bool {
+	dg, ok := old.(*DataGatherer)
+	if !ok {
+		return false
+	}
+	return !reflect.DeepEqual(g, dg)
 }
 
 // Fetch loads and returns the data from the LocalDatagatherer's dataPath

--- a/pkg/datagatherer/local/local.go
+++ b/pkg/datagatherer/local/local.go
@@ -44,6 +44,10 @@ func (g *DataGatherer) Run(stopCh <-chan struct{}) error {
 	return fmt.Errorf("data gatherer's informer was not initialized")
 }
 
+func (g *DataGatherer) Delete() error {
+	return nil
+}
+
 // WaitForCacheSync waits for the data gatherer's informers cache to sync.
 func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return fmt.Errorf("timed out waiting for caches to sync")

--- a/pkg/datagatherer/versionchecker/versionchecker.go
+++ b/pkg/datagatherer/versionchecker/versionchecker.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"reflect"
 	"strings"
 	"time"
 
@@ -293,22 +292,6 @@ func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 		return err
 	}
 	return g.nodeDynamicDg.WaitForCacheSync(stopCh)
-}
-
-func (g *DataGatherer) Equals(old datagatherer.DataGatherer) bool {
-	// shallow equality
-	dg, ok := old.(*DataGatherer)
-	if !ok {
-		return false
-	}
-
-	if !reflect.DeepEqual(g.nodeArchitecture, dg.nodeArchitecture) ||
-		!reflect.DeepEqual(g.versionCheckerOptions, dg.versionCheckerOptions) ||
-		!reflect.DeepEqual(g.config, dg.config) || !g.podDynamicDg.Equals(dg.podDynamicDg) ||
-		!g.nodeDynamicDg.Equals(dg.nodeDynamicDg) {
-		return false
-	}
-	return true
 }
 
 // Fetch retrieves cluster information from GKE.

--- a/pkg/datagatherer/versionchecker/versionchecker.go
+++ b/pkg/datagatherer/versionchecker/versionchecker.go
@@ -294,6 +294,20 @@ func (g *DataGatherer) WaitForCacheSync(stopCh <-chan struct{}) error {
 	return g.nodeDynamicDg.WaitForCacheSync(stopCh)
 }
 
+func (g *DataGatherer) Delete() error {
+	if g.podDynamicDg != nil {
+		if err := g.podDynamicDg.Delete(); err != nil {
+			return err
+		}
+	}
+	if g.nodeDynamicDg != nil {
+		if err := g.nodeDynamicDg.Delete(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Fetch retrieves cluster information from GKE.
 func (g *DataGatherer) Fetch() (interface{}, error) {
 	// Get nodes information to update version-checker architecture structure

--- a/pkg/datagatherer/versionchecker/versionchecker_test.go
+++ b/pkg/datagatherer/versionchecker/versionchecker_test.go
@@ -166,17 +166,25 @@ registries:
 `, kubeConfigPath, hostConfigPath)
 
 	config := Config{}
+	ctx := context.Background()
 	err = yaml.Unmarshal([]byte(textCfg), &config)
 	if err != nil {
 		t.Fatalf("failed to load config: %+v", err)
 	}
 
-	dg, err := config.NewDataGatherer(context.Background())
+	dg, err := config.NewDataGatherer(ctx)
 	if err != nil {
 		t.Fatalf("failed create new dg %s", err)
 	}
 
-	rawResults, err := dg.Fetch()
+	vcDg := dg.(*DataGatherer)
+	vcDg.Run(ctx.Done())
+	err = vcDg.WaitForCacheSync(ctx.Done())
+	if err != nil {
+		t.Fatalf("unexpected client error: %+v", err)
+	}
+
+	rawResults, err := vcDg.Fetch()
 	if err != nil {
 		t.Fatalf("failed fetch data: %s", err)
 	}


### PR DESCRIPTION
This PR introduces informers to dynamic data gatherer.
This allows all resources to be sent to backend not only the ones
present in the snapshot.



<details>
<summary><b>Missing resources</b></summary>

```
2021/03/19 17:22:55 No credentials file was specified. Starting client with no authentication...
2021/03/19 17:22:56 failed to start and cache sync "k8s-dynamic" data gatherer "k8s/certificates": timed out waiting for caches to sync
2021/03/19 17:22:56 failed to start and cache sync "k8s-dynamic" data gatherer "k8s/certificaterequests": timed out waiting for caches to sync
2021/03/19 17:22:56 Successfully gathered data for "k8s/pods"
2021/03/19 17:22:56 Successfully gathered data for "k8s/secrets"
2021/03/19 17:22:56 Successfully gathered data for "k8s/ingresses"
2021/03/19 17:22:56 Successfully gathered data for "k8s-discovery"
2021/03/19 17:22:56 The following 2 data gatherer(s) have failed:
        * k8s/certificates: resource type must be specified
        * k8s/certificaterequests: resource type must be specified 
Retrying...
2021/03/19 17:22:56 The following 2 data gatherer(s) have failed:
        * k8s/certificates: resource type must be specified
        * k8s/certificaterequests: resource type must be specified 
Retrying...
2021/03/19 17:22:57 The following 2 data gatherer(s) have failed:
        * k8s/certificates: resource type must be specified
        * k8s/certificaterequests: resource type must be specified 
Retrying...
```

</details>

Testing on KIND cluster
<details>
<summary><b>agent.yaml</b></summary>

```yaml
cluster_id: "my_cert_cluster"
data-gatherers:
# pods data is used in the pods and application_versions packages
- kind: "k8s-dynamic"
  name: "k8s/pods"
  config:
    include-namespaces:
      - default
    resource-type:
      resource: pods
      version: v1
```
</details>

<details>
<summary><b>test app</b></summary>

```yaml
# hello-kubernetes.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hello-kubernetes
spec:
  replicas: 3
  selector:
    matchLabels:
      app: hello-kubernetes
  template:
    metadata:
      labels:
        app: hello-kubernetes
    spec:
      containers:
      - name: hello-kubernetes
        image: hello-kubernetes:1.9
        ports:
        - containerPort: 8080
```
</details>

<details>
<summary><b>output.json (nothing deployed yet on default namespace, no deletedAt field)</b></summary>

```json
[
  {
    "cluster_id": "my_cert_cluster",
    "data-gatherer": "k8s/pods",
    "timestamp": "2021-03-18T18:20:45Z",
    "data": {
      "items": []
    }
  }
]
```
</details>

deploy the app

running agent `./preflight agent -c local_agent_config.yaml --period "0h1m0s" --output-path "./output.json"`

<details>
<summary><b>output.json (app deployed on default namespace)</b></summary>

```json
[
  {
    "cluster_id": "my_cert_cluster",
    "data-gatherer": "k8s/pods",
    "timestamp": "2021-03-18T18:45:43Z",
    "data": {
      "items": [
        {
          "resource": {
            "apiVersion": "v1",
            "kind": "Pod",
            "metadata": {
              "creationTimestamp": "2021-03-18T18:44:05Z",
              "generateName": "hello-kubernetes-f8bb585f9-",
              "labels": {
                "app": "hello-kubernetes",
                "pod-template-hash": "f8bb585f9"
              },
              "name": "hello-kubernetes-f8bb585f9-xrvjs",
              "namespace": "default",
              "ownerReferences": [
                {
                  "apiVersion": "apps/v1",
                  "blockOwnerDeletion": true,
                  "controller": true,
                  "kind": "ReplicaSet",
                  "name": "hello-kubernetes-f8bb585f9",
                  "uid": "b3e21e58-fa65-4375-a6ad-e82b0cef0537"
                }
              ],
              "resourceVersion": "65260",
              "selfLink": "/api/v1/namespaces/default/pods/hello-kubernetes-f8bb585f9-xrvjs",
              "uid": "2290cc1b-adb7-49f4-817f-0e5d4bf18a42"
            },
            "spec": {
              "containers": [
                {
                  "image": "hello-kubernetes:1.9",
                  "imagePullPolicy": "IfNotPresent",
                  "name": "hello-kubernetes",
                  "ports": [
                    {
                      "containerPort": 8080,
                      "protocol": "TCP"
                    }
                  ],
                  "resources": {},
                  "terminationMessagePath": "/dev/termination-log",
                  "terminationMessagePolicy": "File",
                  "volumeMounts": [
                    {
                      "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
                      "name": "default-token-2rqjg",
                      "readOnly": true
                    }
                  ]
                }
              ],
              "dnsPolicy": "ClusterFirst",
              "enableServiceLinks": true,
              "nodeName": "kind-control-plane",
              "priority": 0,
              "restartPolicy": "Always",
              "schedulerName": "default-scheduler",
              "securityContext": {},
              "serviceAccount": "default",
              "serviceAccountName": "default",
              "terminationGracePeriodSeconds": 30,
              "tolerations": [
                {
                  "effect": "NoExecute",
                  "key": "node.kubernetes.io/not-ready",
                  "operator": "Exists",
                  "tolerationSeconds": 300
                },
                {
                  "effect": "NoExecute",
                  "key": "node.kubernetes.io/unreachable",
                  "operator": "Exists",
                  "tolerationSeconds": 300
                }
              ],
              "volumes": [
                {
                  "name": "default-token-2rqjg",
                  "secret": {
                    "defaultMode": 420,
                    "secretName": "default-token-2rqjg"
                  }
                }
              ]
            },
            "status": {
              "conditions": [
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "status": "True",
                  "type": "Initialized"
                },
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "message": "containers with unready status: [hello-kubernetes]",
                  "reason": "ContainersNotReady",
                  "status": "False",
                  "type": "Ready"
                },
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "message": "containers with unready status: [hello-kubernetes]",
                  "reason": "ContainersNotReady",
                  "status": "False",
                  "type": "ContainersReady"
                },
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "status": "True",
                  "type": "PodScheduled"
                }
              ],
              "containerStatuses": [
                {
                  "image": "hello-kubernetes:1.9",
                  "imageID": "",
                  "lastState": {},
                  "name": "hello-kubernetes",
                  "ready": false,
                  "restartCount": 0,
                  "started": false,
                  "state": {
                    "waiting": {
                      "message": "Back-off pulling image \"hello-kubernetes:1.9\"",
                      "reason": "ImagePullBackOff"
                    }
                  }
                }
              ],
              "hostIP": "172.17.0.2",
              "phase": "Pending",
              "podIP": "10.244.0.28",
              "podIPs": [
                {
                  "ip": "10.244.0.28"
                }
              ],
              "qosClass": "BestEffort",
              "startTime": "2021-03-18T18:44:05Z"
            }
          }
        },
        {
          "resource": {
            "apiVersion": "v1",
            "kind": "Pod",
            "metadata": {
              "creationTimestamp": "2021-03-18T18:44:05Z",
              "generateName": "hello-kubernetes-f8bb585f9-",
              "labels": {
                "app": "hello-kubernetes",
                "pod-template-hash": "f8bb585f9"
              },
              "name": "hello-kubernetes-f8bb585f9-z4jd6",
              "namespace": "default",
              "ownerReferences": [
                {
                  "apiVersion": "apps/v1",
                  "blockOwnerDeletion": true,
                  "controller": true,
                  "kind": "ReplicaSet",
                  "name": "hello-kubernetes-f8bb585f9",
                  "uid": "b3e21e58-fa65-4375-a6ad-e82b0cef0537"
                }
              ],
              "resourceVersion": "65237",
              "selfLink": "/api/v1/namespaces/default/pods/hello-kubernetes-f8bb585f9-z4jd6",
              "uid": "18d42ff5-1bac-4c7c-9183-3214c6a6b5da"
            },
            "spec": {
              "containers": [
                {
                  "image": "hello-kubernetes:1.9",
                  "imagePullPolicy": "IfNotPresent",
                  "name": "hello-kubernetes",
                  "ports": [
                    {
                      "containerPort": 8080,
                      "protocol": "TCP"
                    }
                  ],
                  "resources": {},
                  "terminationMessagePath": "/dev/termination-log",
                  "terminationMessagePolicy": "File",
                  "volumeMounts": [
                    {
                      "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
                      "name": "default-token-2rqjg",
                      "readOnly": true
                    }
                  ]
                }
              ],
              "dnsPolicy": "ClusterFirst",
              "enableServiceLinks": true,
              "nodeName": "kind-control-plane",
              "priority": 0,
              "restartPolicy": "Always",
              "schedulerName": "default-scheduler",
              "securityContext": {},
              "serviceAccount": "default",
              "serviceAccountName": "default",
              "terminationGracePeriodSeconds": 30,
              "tolerations": [
                {
                  "effect": "NoExecute",
                  "key": "node.kubernetes.io/not-ready",
                  "operator": "Exists",
                  "tolerationSeconds": 300
                },
                {
                  "effect": "NoExecute",
                  "key": "node.kubernetes.io/unreachable",
                  "operator": "Exists",
                  "tolerationSeconds": 300
                }
              ],
              "volumes": [
                {
                  "name": "default-token-2rqjg",
                  "secret": {
                    "defaultMode": 420,
                    "secretName": "default-token-2rqjg"
                  }
                }
              ]
            },
            "status": {
              "conditions": [
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "status": "True",
                  "type": "Initialized"
                },
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "message": "containers with unready status: [hello-kubernetes]",
                  "reason": "ContainersNotReady",
                  "status": "False",
                  "type": "Ready"
                },
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "message": "containers with unready status: [hello-kubernetes]",
                  "reason": "ContainersNotReady",
                  "status": "False",
                  "type": "ContainersReady"
                },
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "status": "True",
                  "type": "PodScheduled"
                }
              ],
              "containerStatuses": [
                {
                  "image": "hello-kubernetes:1.9",
                  "imageID": "",
                  "lastState": {},
                  "name": "hello-kubernetes",
                  "ready": false,
                  "restartCount": 0,
                  "started": false,
                  "state": {
                    "waiting": {
                      "message": "Back-off pulling image \"hello-kubernetes:1.9\"",
                      "reason": "ImagePullBackOff"
                    }
                  }
                }
              ],
              "hostIP": "172.17.0.2",
              "phase": "Pending",
              "podIP": "10.244.0.27",
              "podIPs": [
                {
                  "ip": "10.244.0.27"
                }
              ],
              "qosClass": "BestEffort",
              "startTime": "2021-03-18T18:44:05Z"
            }
          }
        },
        {
          "resource": {
            "apiVersion": "v1",
            "kind": "Pod",
            "metadata": {
              "creationTimestamp": "2021-03-18T18:44:05Z",
              "generateName": "hello-kubernetes-f8bb585f9-",
              "labels": {
                "app": "hello-kubernetes",
                "pod-template-hash": "f8bb585f9"
              },
              "name": "hello-kubernetes-f8bb585f9-2jnqz",
              "namespace": "default",
              "ownerReferences": [
                {
                  "apiVersion": "apps/v1",
                  "blockOwnerDeletion": true,
                  "controller": true,
                  "kind": "ReplicaSet",
                  "name": "hello-kubernetes-f8bb585f9",
                  "uid": "b3e21e58-fa65-4375-a6ad-e82b0cef0537"
                }
              ],
              "resourceVersion": "65275",
              "selfLink": "/api/v1/namespaces/default/pods/hello-kubernetes-f8bb585f9-2jnqz",
              "uid": "822fcbe5-5d5d-476e-8a48-cc9588329873"
            },
            "spec": {
              "containers": [
                {
                  "image": "hello-kubernetes:1.9",
                  "imagePullPolicy": "IfNotPresent",
                  "name": "hello-kubernetes",
                  "ports": [
                    {
                      "containerPort": 8080,
                      "protocol": "TCP"
                    }
                  ],
                  "resources": {},
                  "terminationMessagePath": "/dev/termination-log",
                  "terminationMessagePolicy": "File",
                  "volumeMounts": [
                    {
                      "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
                      "name": "default-token-2rqjg",
                      "readOnly": true
                    }
                  ]
                }
              ],
              "dnsPolicy": "ClusterFirst",
              "enableServiceLinks": true,
              "nodeName": "kind-control-plane",
              "priority": 0,
              "restartPolicy": "Always",
              "schedulerName": "default-scheduler",
              "securityContext": {},
              "serviceAccount": "default",
              "serviceAccountName": "default",
              "terminationGracePeriodSeconds": 30,
              "tolerations": [
                {
                  "effect": "NoExecute",
                  "key": "node.kubernetes.io/not-ready",
                  "operator": "Exists",
                  "tolerationSeconds": 300
                },
                {
                  "effect": "NoExecute",
                  "key": "node.kubernetes.io/unreachable",
                  "operator": "Exists",
                  "tolerationSeconds": 300
                }
              ],
              "volumes": [
                {
                  "name": "default-token-2rqjg",
                  "secret": {
                    "defaultMode": 420,
                    "secretName": "default-token-2rqjg"
                  }
                }
              ]
            },
            "status": {
              "conditions": [
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "status": "True",
                  "type": "Initialized"
                },
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "message": "containers with unready status: [hello-kubernetes]",
                  "reason": "ContainersNotReady",
                  "status": "False",
                  "type": "Ready"
                },
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "message": "containers with unready status: [hello-kubernetes]",
                  "reason": "ContainersNotReady",
                  "status": "False",
                  "type": "ContainersReady"
                },
                {
                  "lastProbeTime": null,
                  "lastTransitionTime": "2021-03-18T18:44:05Z",
                  "status": "True",
                  "type": "PodScheduled"
                }
              ],
              "containerStatuses": [
                {
                  "image": "hello-kubernetes:1.9",
                  "imageID": "",
                  "lastState": {},
                  "name": "hello-kubernetes",
                  "ready": false,
                  "restartCount": 0,
                  "started": false,
                  "state": {
                    "waiting": {
                      "message": "Back-off pulling image \"hello-kubernetes:1.9\"",
                      "reason": "ImagePullBackOff"
                    }
                  }
                }
              ],
              "hostIP": "172.17.0.2",
              "phase": "Pending",
              "podIP": "10.244.0.26",
              "podIPs": [
                {
                  "ip": "10.244.0.26"
                }
              ],
              "qosClass": "BestEffort",
              "startTime": "2021-03-18T18:44:05Z"
            }
          }
        }
      ]
    }
  }
]
```
</details>

**delete app from default**

<details>
<summary><b>output.json (app deleted from the default namespace)</b></summary>

```json
[
  {
    "cluster_id": "my_cert_cluster",
    "data-gatherer": "k8s/pods",
    "timestamp": "2021-03-18T18:49:43Z",
    "data": {
      "items": [
        {
          "resource": {
            "apiVersion": "v1",
            "kind": "Pod",
            "metadata": {
              "creationTimestamp": "2021-03-18T18:44:05Z"
			  }
          },
          "deletedAt": "2021-03-18T18:47:09Z"
        },
        {
          "resource": {
            "apiVersion": "v1",
            "kind": "Pod",
            "metadata": {
              "creationTimestamp": "2021-03-18T18:44:05Z"
			}
          },
          "deletedAt": "2021-03-18T18:47:09Z"
        },
        {
          "resource": {
            "apiVersion": "v1",
            "kind": "Pod",
            "metadata": {
              "creationTimestamp": "2021-03-18T18:44:05Z"
			}
          },
          "deletedAt": "2021-03-18T18:47:09Z"
        }
      ]
    }
  }
]
```
</details>

Signed-off-by: oluwole.fadeyi <oluwole.fadeyi@jetstack.io>