### PR TITLE
Run agent as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM gcr.io/distroless/base:nonroot
 # Ref: https://docs.docker.com/buildx/working-with-buildx/
 ARG TARGETPLATFORM
 
+USER preflight
+
 COPY ./builds/${TARGETPLATFORM}/preflight /bin/preflight
 # load in an example config file
 ADD ./agent.yaml /etc/preflight/agent.yaml


### PR DESCRIPTION
This is a requirement in openshift defaults for unprivileged containers

Related to https://github.com/jetstack/preflight-platform/issues/1330

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>