### PR TITLE
Use moby/buildkit:master when setting up buildx

### DIFF
--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -45,6 +45,8 @@ jobs:
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+      with:
+        driver-opts: image=moby/buildkit:master
     - name: Login to registry
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -30,6 +30,8 @@ jobs:
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+      with:
+        driver-opts: image=moby/buildkit:master
     - name: Login to registry
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,5 +48,7 @@ jobs:
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+      with:
+        driver-opts: image=moby/buildkit:master
     - name: Build images
       run: make build-docker-image


### PR DESCRIPTION
Suggested fix when hitting the 401 authorized error that we are when trying to push new images:

https://github.com/docker/buildx/issues/327

Signed-off-by: David Bond <davidsbond93@gmail.com>