### PR TITLE
Use USER 1000:1000 in agent image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM gcr.io/distroless/base:nonroot
 # Ref: https://docs.docker.com/buildx/working-with-buildx/
 ARG TARGETPLATFORM
 
+USER 1000:1000
+
 COPY ./builds/${TARGETPLATFORM}/preflight /bin/preflight
 # load in an example config file
 ADD ./agent.yaml /etc/preflight/agent.yaml


### PR DESCRIPTION
We're running issues getting the agent to work out of the box on OpenShift clusters due to the
way they set up security contexts. We're trying to align our Docker image with cert-manager's
as their deployments work out of the box with the restrictions that OpenShifts's SecurityContextConstraints
custom resource applies by default.

Signed-off-by: David Bond <davidsbond93@gmail.com>