### PR TITLE
Switch to distroless/static base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base:nonroot
+FROM gcr.io/distroless/static
 
 # TARGETPLATFORM comes from the buildx context and it will be something like `linux/arm64/v8` or `linux/amd64`.
 # Ref: https://docs.docker.com/buildx/working-with-buildx/


### PR DESCRIPTION
The initial switch to USER 1000:1000 didn't seem to solve the problem, going to try
using the same base image that cert-manager does also.

Signed-off-by: David Bond <davidsbond93@gmail.com>